### PR TITLE
Adding BY25Q64AS support to m25p80

### DIFF
--- a/drivers/mtd/devices/m25p80.c
+++ b/drivers/mtd/devices/m25p80.c
@@ -971,6 +971,11 @@ static const struct spi_device_id m25p_ids[] = {
 	M25P80_4_WIRE_ALL_SUPPORT) },
 	{ "XM25QH64A", INFO(0x207017, 0, 64 * 1024, 128, 0,
 	M25P80_4_WIRE_ALL_SUPPORT) },
+	
+	// BY25Q64AS 
+	{ "by25q64as", INFO(0x684017, 0, 64 * 1024, 128, 0, 0 )},
+
+
 	{ },
 };
 MODULE_DEVICE_TABLE(spi, m25p_ids);


### PR DESCRIPTION
Patching `m25p80.c` to allow OpenIPC kernel read the flash on my IP camera.
More details in this [report](https://github.com/didkivskyy/linux/issues/1).
