### PR TITLE
Ingenic t31 kernel fix clock control kernel messages

### DIFF
--- a/arch/mips/xburst/soc-m200/common/clk/clk.c
+++ b/arch/mips/xburst/soc-m200/common/clk/clk.c
@@ -330,10 +330,9 @@ static int enable_write(struct file *file, const char __user *buffer,size_t coun
 		else if(count && (buffer[0] == '0'))
 			clk_disable(tmp);
 		else
-                        printk("To control the clock state, use:\n"
-                               "\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n"
-                               "or\n"
-                               "\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock.\n");
+                        printk("To control the state of an Ingenic SOC clock, use:\n"
+                               "\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock\n"
+                               "\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n");
 		clk_put(tmp);
 	}
 	return count;

--- a/arch/mips/xburst/soc-m200/common/clk/clk.c
+++ b/arch/mips/xburst/soc-m200/common/clk/clk.c
@@ -330,7 +330,10 @@ static int enable_write(struct file *file, const char __user *buffer,size_t coun
 		else if(count && (buffer[0] == '0'))
 			clk_disable(tmp);
 		else
-			printk("\"echo 1 > enable\" or \"echo 0 > enable \" ");
+                        printk("To control the clock state, use:\n"
+                               "\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n"
+                               "or\n"
+                               "\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock.\n");
 		clk_put(tmp);
 	}
 	return count;

--- a/arch/mips/xburst/soc-t10/common/clk/clk.c
+++ b/arch/mips/xburst/soc-t10/common/clk/clk.c
@@ -332,7 +332,10 @@ static int enable_write(struct file *file, const char __user *buffer,size_t coun
 		else if(count && (buffer[0] == '0'))
 			clk_disable(tmp);
 		else
-			printk("\"echo 1 > enable\" or \"echo 0 > enable \" ");
+                        printk("To control the clock state, use:\n"
+                               "\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n"
+                               "or\n"
+                               "\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock.\n");
 		clk_put(tmp);
 	}
 	return count;

--- a/arch/mips/xburst/soc-t10/common/clk/clk.c
+++ b/arch/mips/xburst/soc-t10/common/clk/clk.c
@@ -332,10 +332,9 @@ static int enable_write(struct file *file, const char __user *buffer,size_t coun
 		else if(count && (buffer[0] == '0'))
 			clk_disable(tmp);
 		else
-                        printk("To control the clock state, use:\n"
-                               "\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n"
-                               "or\n"
-                               "\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock.\n");
+                        printk("To control the state of an Ingenic SOC clock, use:\n"
+                               "\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock\n"
+                               "\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n");
 		clk_put(tmp);
 	}
 	return count;

--- a/arch/mips/xburst/soc-t15/common/clk/clk.c
+++ b/arch/mips/xburst/soc-t15/common/clk/clk.c
@@ -332,7 +332,10 @@ static int enable_write(struct file *file, const char __user *buffer,size_t coun
 		else if(count && (buffer[0] == '0'))
 			clk_disable(tmp);
 		else
-			printk("\"echo 1 > enable\" or \"echo 0 > enable \" ");
+                        printk("To control the clock state, use:\n"
+                               "\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n"
+                               "or\n"
+                               "\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock.\n");
 		clk_put(tmp);
 	}
 	return count;

--- a/arch/mips/xburst/soc-t15/common/clk/clk.c
+++ b/arch/mips/xburst/soc-t15/common/clk/clk.c
@@ -332,10 +332,9 @@ static int enable_write(struct file *file, const char __user *buffer,size_t coun
 		else if(count && (buffer[0] == '0'))
 			clk_disable(tmp);
 		else
-                        printk("To control the clock state, use:\n"
-                               "\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n"
-                               "or\n"
-                               "\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock.\n");
+                        printk("To control the state of an Ingenic SOC clock, use:\n"
+                               "\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock\n"
+                               "\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n");
 		clk_put(tmp);
 	}
 	return count;

--- a/arch/mips/xburst/soc-t20/common/clk/clk.c
+++ b/arch/mips/xburst/soc-t20/common/clk/clk.c
@@ -335,7 +335,10 @@ static int enable_write(struct file *file, const char __user *buffer,size_t coun
 		else if(count && (buffer[0] == '0'))
 			clk_disable(tmp);
 		else
-			printk("\"echo 1 > enable\" or \"echo 0 > enable \" ");
+                        printk("To control the clock state, use:\n"
+                               "\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n"
+                               "or\n"
+                               "\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock.\n");
 		clk_put(tmp);
 	}
 	return count;

--- a/arch/mips/xburst/soc-t20/common/clk/clk.c
+++ b/arch/mips/xburst/soc-t20/common/clk/clk.c
@@ -335,10 +335,9 @@ static int enable_write(struct file *file, const char __user *buffer,size_t coun
 		else if(count && (buffer[0] == '0'))
 			clk_disable(tmp);
 		else
-                        printk("To control the clock state, use:\n"
-                               "\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n"
-                               "or\n"
-                               "\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock.\n");
+                        printk("To control the state of an Ingenic SOC clock, use:\n"
+                               "\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock\n"
+                               "\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n");
 		clk_put(tmp);
 	}
 	return count;

--- a/arch/mips/xburst/soc-t21/common/clk/clk.c
+++ b/arch/mips/xburst/soc-t21/common/clk/clk.c
@@ -338,10 +338,9 @@ static int enable_write(struct file *file, const char __user *buffer,size_t coun
 		else if(count && (buffer[0] == '0'))
 			clk_disable(tmp);
 		else
-                        printk("To control the clock state, use:\n"
-                               "\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n"
-                               "or\n"
-                               "\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock.\n");
+                        printk("To control the state of an Ingenic SOC clock, use:\n"
+                               "\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock\n"
+                               "\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n");
 		clk_put(tmp);
 	}
 	return count;

--- a/arch/mips/xburst/soc-t21/common/clk/clk.c
+++ b/arch/mips/xburst/soc-t21/common/clk/clk.c
@@ -338,7 +338,10 @@ static int enable_write(struct file *file, const char __user *buffer,size_t coun
 		else if(count && (buffer[0] == '0'))
 			clk_disable(tmp);
 		else
-			printk("\"echo 1 > enable\" or \"echo 0 > enable \" ");
+                        printk("To control the clock state, use:\n"
+                               "\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n"
+                               "or\n"
+                               "\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock.\n");
 		clk_put(tmp);
 	}
 	return count;

--- a/arch/mips/xburst/soc-t30/common/clk/clk.c
+++ b/arch/mips/xburst/soc-t30/common/clk/clk.c
@@ -338,10 +338,9 @@ static int enable_write(struct file *file, const char __user *buffer,size_t coun
 		else if(count && (buffer[0] == '0'))
 			clk_disable(tmp);
 		else
-                        printk("To control the clock state, use:\n"
-                               "\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n"
-                               "or\n"
-                               "\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock.\n");
+                        printk("To control the state of an Ingenic SOC clock, use:\n"
+                               "\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock\n"
+                               "\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n");
 		clk_put(tmp);
 	}
 	return count;

--- a/arch/mips/xburst/soc-t30/common/clk/clk.c
+++ b/arch/mips/xburst/soc-t30/common/clk/clk.c
@@ -338,7 +338,10 @@ static int enable_write(struct file *file, const char __user *buffer,size_t coun
 		else if(count && (buffer[0] == '0'))
 			clk_disable(tmp);
 		else
-			printk("\"echo 1 > enable\" or \"echo 0 > enable \" ");
+                        printk("To control the clock state, use:\n"
+                               "\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n"
+                               "or\n"
+                               "\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock.\n");
 		clk_put(tmp);
 	}
 	return count;

--- a/arch/mips/xburst/soc-t31/common/clk/clk.c
+++ b/arch/mips/xburst/soc-t31/common/clk/clk.c
@@ -339,7 +339,10 @@ static int enable_write(struct file *file, const char __user *buffer,size_t coun
 		else if(count && (buffer[0] == '0'))
 			clk_disable(tmp);
 		else
-			printk("\"echo 1 > enable\" or \"echo 0 > enable \" ");
+			printk("To control the clock state, use:\n"
+			       "\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n"
+			       "or\n"
+			       "\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock.\n");
 		clk_put(tmp);
 	}
 	return count;

--- a/arch/mips/xburst/soc-t31/common/clk/clk.c
+++ b/arch/mips/xburst/soc-t31/common/clk/clk.c
@@ -339,10 +339,9 @@ static int enable_write(struct file *file, const char __user *buffer,size_t coun
 		else if(count && (buffer[0] == '0'))
 			clk_disable(tmp);
 		else
-			printk("To control the clock state, use:\n"
-			       "\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n"
-			       "or\n"
-			       "\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock.\n");
+                        printk("To control the state of an Ingenic SOC clock, use:\n"
+                               "\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock\n"
+                               "\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n");
 		clk_put(tmp);
 	}
 	return count;


### PR DESCRIPTION
Enhance the clarity and meaning of the messages printed during boot by the Ingenic clock and power manager.

Applies to:

T10
T15
T20
T21
T30
T31

Tested on T20 & 31

---

kernel log before:

```
[    6.235261] "echo 1 > enable" or "echo 0 > enable "
```

kernel log after:
```
[    6.260984] To control the state of an Ingenic SOC clock, use:
[    6.260984] "echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable" to disable the clock
[    6.260984] "echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable" to enable the clock
```