### PR TITLE
gpio.c only print the stack if CONFIG_DYNAMIC_DEBUG

### DIFF
--- a/arch/mips/xburst/soc-t31/common/gpio.c
+++ b/arch/mips/xburst/soc-t31/common/gpio.c
@@ -508,16 +508,24 @@ static int jz_gpio_request(struct gpio_chip *chip, unsigned offset)
 {
 	struct jzgpio_chip *jz = gpio2jz(chip);
 
+	int debug_level;
+
 	if(!test_bit(offset, jz->gpio_map)) {
-		printk(KERN_WARNING "gpio has conflict\n");
+		dev_dbg(chip->dev, "gpio has conflict\n");
 		return -EINVAL;
 	}
 	if(jz->dev_map[0] & (1 << offset)) {
-		printk("gpio:jz->reg = 0x%x\n", (unsigned int)jz->reg);
-		printk("gpio pin: 0x%x\n", 1 << offset);
-		printk("jz->dev_map[0]: 0x%x\n", (unsigned int)jz->dev_map[0]);
-		dump_stack();
-		printk("%s:gpio functions has redefinition", __FILE__);
+		dev_dbg(chip->dev, "gpio:jz->reg = 0x%x\n", (unsigned int)jz->reg);
+		dev_dbg(chip->dev, "gpio pin: 0x%x\n", 1 << offset);
+		dev_dbg(chip->dev, "jz->dev_map[0]: 0x%x\n", (unsigned int)jz->dev_map[0]);
+
+		// Get the debug level
+		debug_level = printk_get_level(KERN_DEBUG "debug");
+		if (debug_level <= console_loglevel) {
+			dump_stack();
+		}
+
+		dev_dbg(chip->dev, "%s:gpio functions has redefinition", __FILE__);
 	}
 	jz->dev_map[0] |= 1 << offset;
 


### PR DESCRIPTION
gpio.c only print the stack if CONFIG_DYNAMIC_DEBUG

Resolved excessive logging from gpio debug stack printing
No error messages will be displayed system boot when gpio's are claimed.
Messages will now only appear if `CONFIG_DYNAMIC_DEBUG` is enabled in the kernel, and the user issues:
`mount -t debugfs none /sys/kernel/debug`
`echo 'file gpio.c +p' > /sys/kernel/debug/dynamic_debug/control`

before:
```
[    7.199318] gpio:jz->reg = 0xb0011000
[    7.199330] gpio pin: 0x100000
[    7.199336] jz->dev_map[0]: 0x89f86f00
[    7.199346] CPU: 0 PID: 681 Comm: load_ingenic Tainted: G           O 3.10.14__isvp_swan_1.0__ #12
[    7.199354] Stack : 00000000 00000000 00000000 00000000 8058316a 00000056 30001c01 80580000
[    7.199359] 	  8049e04c 81146a58 80508bc7 80582904 000002a9 8050c46c 00000063 00000030
[    7.199359] 	  770369ec 803efd9c 00000000 800371fc 00000002 8290301f 8049f9bc 81775dc4
[    7.199359] 	  00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[    7.199359] 	  00000000 00000000 00000000 00000000 00000000 00000000 00000000 81775d50
[    7.199359] 	  ...
[    7.199433] Call Trace:
[    7.199447] [<8001fdf4>] show_stack+0x58/0x70
[    7.199460] [<80018298>] jz_gpio_request+0xd8/0x13c
[    7.199470] [<801d04e8>] gpiod_request+0x1d0/0x220
[    7.199482] [<c0780058>] claim_gpio+0x58/0xbc [gpio]
[    7.199492] [<c0780160>] claim_proc_write+0xa4/0xe4 [gpio]
[    7.199503] [<80125388>] proc_reg_write+0x80/0x94
[    7.199514] [<800d2784>] vfs_write+0xd8/0x198
[    7.199522] [<800d2dec>] SyS_write+0x60/0xa4
[    7.199532] [<80022adc>] stack_done+0x20/0x44
[    7.199538] 
[    7.199542] arch/mips/xburst/soc-t31/common/gpio.c:gpio functions has redefinitiongpio:jz->reg = 0xb0011000
[    7.216788] gpio pin: 0x200000
[    7.216796] jz->dev_map[0]: 0x89f86f00
[    7.216807] CPU: 0 PID: 681 Comm: load_ingenic Tainted: G           O 3.10.14__isvp_swan_1.0__ #12
[    7.216813] Stack : 00000000 00000000 00000000 00000000 8058316a 00000056 30001c01 80580000
[    7.216813] 	  8049e04c 81146a58 80508bc7 80582904 000002a9 8050c46c 00000063 00000030
[    7.216813] 	  770369ec 803efd9c 00000000 800371fc 00000002 8290301f 8049f9bc 81775dc4
[    7.216813] 	  00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[    7.216813] 	  00000000 00000000 00000000 00000000 00000000 00000000 00000000 81775d50
[    7.216813] 	  ...
[    7.216890] Call Trace:
[    7.216904] [<8001fdf4>] show_stack+0x58/0x70
[    7.216916] [<80018298>] jz_gpio_request+0xd8/0x13c
[    7.216928] [<801d04e8>] gpiod_request+0x1d0/0x220
[    7.216940] [<c0780058>] claim_gpio+0x58/0xbc [gpio]
[    7.216950] [<c0780160>] claim_proc_write+0xa4/0xe4 [gpio]
[    7.216960] [<80125388>] proc_reg_write+0x80/0x94