### PR TITLE
ingenic-t31: gpio - add missing header

### DIFF
--- a/arch/mips/xburst/soc-t31/common/gpio.c
+++ b/arch/mips/xburst/soc-t31/common/gpio.c
@@ -7,6 +7,7 @@
  * the Free Software Foundation; either version 2 of the License.
  */
 
+#include <linux/device.h>
 #include <linux/kernel.h>
 #include <linux/init.h>
 #include <linux/interrupt.h>


### PR DESCRIPTION
ingenic-t31: gpio - add missing header