### PR TITLE
fix rtl8188eu compilation error

### DIFF
--- a/include/net/cfg80211.h
+++ b/include/net/cfg80211.h
@@ -426,6 +426,7 @@ struct station_parameters {
  * @STATION_INFO_RX_BITRATE: @rxrate fields are filled
  * @STATION_INFO_BSS_PARAM: @bss_param filled
  * @STATION_INFO_CONNECTED_TIME: @connected_time filled
+ * @STATION_INFO_ASSOC_REQ_IES: @assoc_req_ies filled
  */
 enum station_info_flags {
 	STATION_INFO_INACTIVE_TIME	= 1<<0,
@@ -444,7 +445,8 @@ enum station_info_flags {
 	STATION_INFO_SIGNAL_AVG		= 1<<13,
 	STATION_INFO_RX_BITRATE		= 1<<14,
 	STATION_INFO_BSS_PARAM          = 1<<15,
-	STATION_INFO_CONNECTED_TIME	= 1<<16
+	STATION_INFO_CONNECTED_TIME	= 1<<16,
+	STATION_INFO_ASSOC_REQ_IES	= 1<<17
 };
 
 /**


### PR DESCRIPTION
fixes error
```
../rtl8188eu-f4af53305cb1e9a0d8d9957a042f7c01b7121bfc/ioctl_cfg80211.c: In function ‘rtw_cfg80211_indicate_sta_assoc’:
../rtl8188eu-f4af53305cb1e9a0d8d9957a042f7c01b7121bfc/ioctl_cfg80211.c:3398:32: error: ‘STATION_INFO_ASSOC_REQ_IES’ undeclared (first use in this function); did you mean ‘STATION_INFO_TX_RETRIES’?
 3398 |                 sinfo.filled = STATION_INFO_ASSOC_REQ_IES;
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                STATION_INFO_TX_RETRIES

```
when building openipc/firmware like
```
BR2_PACKAGE_RTL8188EU=y BOARD=hi3518ev100 make clean all
```