### PR TITLE
ingenic-t31: switch kernel module debug messages to pr_debug

### DIFF
--- a/arch/mips/xburst/soc-m200/common/clk/clk.c
+++ b/arch/mips/xburst/soc-m200/common/clk/clk.c
@@ -330,7 +330,7 @@ static int enable_write(struct file *file, const char __user *buffer,size_t coun
 		else if(count && (buffer[0] == '0'))
 			clk_disable(tmp);
 		else
-			printk("To control the state of an Ingenic SOC clock, use:\n"
+			pr_debug("To control the state of an Ingenic SOC clock, use:\n"
 				"\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock\n"
 				"\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n");
 		clk_put(tmp);

--- a/arch/mips/xburst/soc-t10/common/clk/clk.c
+++ b/arch/mips/xburst/soc-t10/common/clk/clk.c
@@ -332,7 +332,7 @@ static int enable_write(struct file *file, const char __user *buffer,size_t coun
 		else if(count && (buffer[0] == '0'))
 			clk_disable(tmp);
 		else
-			printk("To control the state of an Ingenic SOC clock, use:\n"
+			pr_debug("To control the state of an Ingenic SOC clock, use:\n"
 				"\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock\n"
 				"\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n");
 		clk_put(tmp);

--- a/arch/mips/xburst/soc-t15/common/clk/clk.c
+++ b/arch/mips/xburst/soc-t15/common/clk/clk.c
@@ -332,7 +332,7 @@ static int enable_write(struct file *file, const char __user *buffer,size_t coun
 		else if(count && (buffer[0] == '0'))
 			clk_disable(tmp);
 		else
-			printk("To control the state of an Ingenic SOC clock, use:\n"
+			pr_debug("To control the state of an Ingenic SOC clock, use:\n"
 				"\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock\n"
 				"\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n");
 		clk_put(tmp);

--- a/arch/mips/xburst/soc-t20/common/clk/clk.c
+++ b/arch/mips/xburst/soc-t20/common/clk/clk.c
@@ -335,7 +335,7 @@ static int enable_write(struct file *file, const char __user *buffer,size_t coun
 		else if(count && (buffer[0] == '0'))
 			clk_disable(tmp);
 		else
-			printk("To control the state of an Ingenic SOC clock, use:\n"
+			pr_debug("To control the state of an Ingenic SOC clock, use:\n"
 				"\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock\n"
 				"\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n");
 		clk_put(tmp);

--- a/arch/mips/xburst/soc-t21/common/clk/clk.c
+++ b/arch/mips/xburst/soc-t21/common/clk/clk.c
@@ -338,7 +338,7 @@ static int enable_write(struct file *file, const char __user *buffer,size_t coun
 		else if(count && (buffer[0] == '0'))
 			clk_disable(tmp);
 		else
-			printk("To control the state of an Ingenic SOC clock, use:\n"
+			pr_debug("To control the state of an Ingenic SOC clock, use:\n"
 				"\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock\n"
 				"\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n");
 		clk_put(tmp);

--- a/arch/mips/xburst/soc-t30/common/clk/clk.c
+++ b/arch/mips/xburst/soc-t30/common/clk/clk.c
@@ -338,7 +338,7 @@ static int enable_write(struct file *file, const char __user *buffer,size_t coun
 		else if(count && (buffer[0] == '0'))
 			clk_disable(tmp);
 		else
-			printk("To control the state of an Ingenic SOC clock, use:\n"
+			pr_debug("To control the state of an Ingenic SOC clock, use:\n"
 				"\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock\n"
 				"\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n");
 		clk_put(tmp);

--- a/arch/mips/xburst/soc-t31/common/clk/clk.c
+++ b/arch/mips/xburst/soc-t31/common/clk/clk.c
@@ -339,7 +339,7 @@ static int enable_write(struct file *file, const char __user *buffer,size_t coun
 		else if(count && (buffer[0] == '0'))
 			clk_disable(tmp);
 		else
-			printk("To control the state of an Ingenic SOC clock, use:\n"
+			pr_debug("To control the state of an Ingenic SOC clock, use:\n"
 				"\"echo 0 > /proc/jz/clock/[CLOCK_NAME]/enable\" to disable the clock\n"
 				"\"echo 1 > /proc/jz/clock/[CLOCK_NAME]/enable\" to enable the clock\n");
 		clk_put(tmp);


### PR DESCRIPTION
Updating my previous PR, #8 , switched from `printk` to `pr_debug` as these are engineering messages, not useful for ordinary users.   They can be enabled on demand by running `switch_debug on`