### PR TITLE
driver: ported sar_adc driver.

### DIFF
--- a/arch/arm/mach-GM/Kconfig
+++ b/arch/arm/mach-GM/Kconfig
@@ -49,6 +49,9 @@ config FTAPBB020
     select DMA_ENGINE
     default n
 
+config GM_SAR_ADC
+    tristate "Supports SAR ADC"
+    default n
 
 #
 # Platform dependent options

--- a/arch/arm/mach-GM/Makefile
+++ b/arch/arm/mach-GM/Makefile
@@ -20,6 +20,14 @@ obj-$(CONFIG_PLATFORM_GM8139)		+= cpufreq.o
 obj-$(CONFIG_PLATFORM_GM8136)		+= cpufreq.o
 endif
 
+ifeq ($(CONFIG_GM_SAR_ADC),y)
+obj-y += sar-adc-drv/sar_adc_drv.o sar-adc-drv/sar_adc_dev.o
+
+obj-$(CONFIG_PLATFORM_GM8287) += sar-adc-drv/gm8287.o    
+obj-$(CONFIG_PLATFORM_GM8139) += sar-adc-drv/gm8139.o  
+obj-$(CONFIG_PLATFORM_GM8136) += sar-adc-drv/gm8136.o
+endif
+
 #
 #Default platform directory set to GM8181
 #TODO: Make this an error, should never happen unless the Kconfig or Makefile is wrong

--- a/arch/arm/mach-GM/include/platform.h
+++ b/arch/arm/mach-GM/include/platform.h
@@ -1,0 +1,60 @@
+#ifndef _IRDET_PLATFORM_H
+#define _IRDET_PLATFORM_H
+#include "sar_adc_drv.h"
+#include "sar_adc_api.h"
+
+#define DEV_IRQ_START 	ADC_WRAP_0_IRQ
+#define DEV_IRQ_END 	ADC_WRAP_0_IRQ
+#define DEV_PA_START 	ADC_WRAP_0_PA_BASE
+#define DEV_PA_END 	ADC_WRAP_0_PA_LIMIT
+
+#if defined(CONFIG_PLATFORM_GM8287)
+#define ADC_WRAP_CLEAR_INT             0x01
+#define ADDA_GET_IO_ADDR(io_add)  
+#define ADDA_UMMAP_IO_ADDR(io_addr)
+
+#elif defined(CONFIG_PLATFORM_GM8139) || defined(CONFIG_PLATFORM_GM8136)
+#define ADDA_PA_START                  ADDA_WRAP_0_PA_BASE
+#define ADDA_PA_END                    ADDA_WRAP_0_PA_LIMIT
+#define TVE100_PA_START                ADDA_WRAP_0_PA_BASE
+#define TVE100_PA_END                  ADDA_WRAP_0_PA_LIMIT
+
+#define ADDA_DAC_REG                   0x14
+#define ADDA_DAC_DET_EN                0x10
+#define ADC_WRAP_CLEAR_INT             0x3F/* xlian2 high/low interrupt flag */
+#define TVE_POWER_DOWN_REG             0x0C
+#endif
+
+
+extern int scu_probe(struct scu_t *p_scu);
+extern int scu_remove(struct scu_t *p_scu);
+extern int set_pinmux(void);
+
+int Platform_Init_Pollign_Timer(struct dev_data *p_dev_data);
+void Platform_Del_Pollign_Timer(void);
+int Platform_Get_Polling_Timer_State(void);
+void Platform_Set_Init_Reg(struct dev_data *p_dev_data);
+void Platform_Process_Volt_Threshold(struct dev_data *p_dev_data); 
+int Platform_SAR_ADC_GetData(struct dev_data *p_dev_data , sar_adc_pub_data* new_data);
+void Platform_Lock_Polling_Mutex(void);
+void Platform_UnLock_Polling_Mutex(void);
+int Platform_Check_Support_XGain(int num);
+unsigned int Platform_Direct_Get_XGain_Value(unsigned int base , int num);
+
+#if defined(CONFIG_PLATFORM_GM8139) || defined(CONFIG_PLATFORM_GM8136)
+int Platform_Get_CVBS_Info(void);
+int Platform_Get_SARADC_Debug(void);
+void Platform_Set_SARADC_Debug(int value);
+int Platform_Force_Set_ADDA_TVBS(int force);
+int Platform_Force_Get_ADDA_TVBS(void);
+int Platform_Set_CVBS_THR_Value(unsigned int on_vlaue,unsigned int off_value);
+int Platform_Get_CVBS_THR_Value(unsigned int *on_vlaue,unsigned int *off_value);
+int Platform_Set_Polling_Time(unsigned int time_val);
+u32 Platform_Get_Polling_Time(void);
+#endif
+
+#if defined(CONFIG_PLATFORM_GM8287)
+int Platform_Get_SARADC_Debug(void);
+#endif
+
+#endif

--- a/arch/arm/mach-GM/include/sar_adc_api.h
+++ b/arch/arm/mach-GM/include/sar_adc_api.h
@@ -1,0 +1,24 @@
+#ifndef __SAR_ADC_IOCTL_H__
+#define __SAR_ADC_IOCTL_H__
+
+#include <linux/ioctl.h>
+
+typedef struct sar_adc_data_tag{
+    unsigned int adc_val;
+    int status;
+}sar_adc_pub_data;
+
+#define KEY_IN      1
+#define KEY_REPEAT  2
+#define KEY_XAIN_0  4
+#define KEY_XAIN_1  8
+#define KEY_XAIN_2  16
+
+#define SAR_ADC_MAGIC 'S'
+#define SAR_ADC_KEY_ADC_DIRECT_READ              _IOR(SAR_ADC_MAGIC, 1, int) 
+#define SAR_ADC_KEY_SET_XGAIN_NUM                _IOWR(SAR_ADC_MAGIC, 2, int) 
+#define SAR_ADC_KEY_SET_REPEAT_DURATION          _IOWR(SAR_ADC_MAGIC, 3, int) 
+
+#endif //end of __SAR_ADC_IOCTL_H__
+
+

--- a/arch/arm/mach-GM/include/sar_adc_dev.h
+++ b/arch/arm/mach-GM/include/sar_adc_dev.h
@@ -1,0 +1,27 @@
+
+#ifndef __SAR_ADC_DEV_H__
+#define __SAR_ADC_DEV_H__
+
+#include "sar_adc_drv.h"
+#include <linux/io.h>
+
+#ifdef __SAR_ADC_DEV_C__
+  #define SAR_ADC_DEV_EXT
+#else
+  #define SAR_ADC_DEV_EXT extern
+#endif
+
+
+
+/* function bit */
+
+#define SAR_ADC_RAW_REG_RD(base, offset)         (ioread32((base)+(offset)))
+#define SAR_ADC_RAW_REG_WR(base, offset, val)    (iowrite32(val, (base)+(offset)))
+
+SAR_ADC_DEV_EXT unsigned long jiffies_diff(unsigned long a, unsigned long b);
+
+SAR_ADC_DEV_EXT void SAR_ADC_ClearInt(unsigned int base);
+SAR_ADC_DEV_EXT unsigned int SAR_ADC_GetData(unsigned int base);
+
+#endif /*__SAR_ADC_DEV_H__*/
+

--- a/arch/arm/mach-GM/include/sar_adc_drv.h
+++ b/arch/arm/mach-GM/include/sar_adc_drv.h
@@ -1,0 +1,164 @@
+#ifndef _FT_ASYNC_H
+#define _FT_ASYNC_H
+
+#include <linux/kernel.h>               /* printk(), min() */
+#include <linux/version.h>
+#include <linux/module.h>
+#include <linux/mm.h>
+#include <linux/cdev.h>
+#include <linux/fs.h>                   /* file_operations */
+#include <linux/slab.h>                 /* kzalloc */
+#include <linux/interrupt.h>            /* free_irq */
+#include <linux/types.h>
+#include <linux/kfifo.h>				/* kfifo */
+#include <asm/signal.h>                 /* SIGIO */
+#include <asm/siginfo.h>                /* POLL_OUT */
+#include <linux/sched.h> 				/* for wake_up() */
+#include <linux/workqueue.h>
+#include <linux/fs.h>
+#include <asm/uaccess.h>				/* copy_from_user */
+#include <linux/poll.h>					/* poll_wait */
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,3,00))
+#include <linux/platform_device.h>
+#include <mach/platform/platform_io.h>
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,28))
+#include <linux/platform_device.h>
+#include <mach/platform/platform_io.h>
+#include <mach/platform/spec.h>
+#elif (LINUX_VERSION_CODE > KERNEL_VERSION(2,6,0))
+#include <linux/device.h>
+#include <asm/arch/fmem.h>
+#include <asm/arch/platform/spec.h>
+#endif
+
+#define HARDWARE_IS_ON
+
+#define DEV_COUNT 1
+#define DEV_NAME "sar_adc_drv"
+#define CLS_NAME "sar_adc_cls"
+#define SARADC_VER "VER:2.5"
+
+#ifdef __KERNEL__
+#define PRINT_E(args...) do { printk(args); }while(0)
+#define PRINT_I(args...) do { printk(args); }while(0)
+#define PRINT_FUNC()     PRINT_I(" * %s\n", __FUNCTION__)
+#else
+#define PRINT_E(args...) do { printf(args); }while(0)
+#define PRINT_I(args...) do { printf(args); }while(0)
+#define PRINT_FUNC()     ();
+#endif
+
+#define DRV_COUNT_RESET() 			    (p_dev_data->driver_count = 0)
+#define DRV_COUNT_INC() 			    (p_dev_data->driver_count++) 
+#define DRV_COUNT_DEC() 			    (p_dev_data->driver_count--) 
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,36))
+#define init_MUTEX(sema) sema_init(sema, 1)
+#endif
+
+#ifdef CONFIG_PLATFORM_GM8287
+/* register offset */
+#define FTSAR_ADC_CR0			0x00
+#define FTSAR_ADC_INT			0x04
+#define FTSAR_ADC_DAT0			0x08
+#define FTSAR_ADC_DAT1			0x0C
+#define FTSAR_ADC_THD0			0x10
+#define FTSAR_ADC_THD1			0x14
+#define FTSAR_ADC_THD2			0x18
+#endif
+
+#if  defined(CONFIG_PLATFORM_GM8139) || defined(CONFIG_PLATFORM_GM8136)
+/* register offset */
+#define FTSAR_ADC_CR0			0x00
+#define FTSAR_ADC_INT			0x04
+#define FTSAR_ADC_DAT0			0x08
+#define FTSAR_ADC_DAT1			0x0C
+#define FTSAR_ADC_DAT2			0x10
+#define FTSAR_ADC_THD0			0x14
+#define FTSAR_ADC_THD1			0x18
+#define FTSAR_ADC_THD2			0x1c
+#define FTSAR_ADC_AUTO_REQ0		0x20
+#define FTSAR_ADC_AUTO_REQ1		0x24
+#define FTSAR_ADC_AUTO_REQ2		0x28
+
+
+#define SW_OUTPUT_VOL_THR_ON       0x28
+#define SW_OUTPUT_VOL_THR_OFF      0x16
+
+#define HW_OUTPUT_VOL_THR_ON       0x78
+#define HW_OUTPUT_VOL_THR_OFF      0x2f
+
+
+#define OUTPUT_VOL_THR_TOP       0x96
+#define OUTPUT_VOL_THR_DOWN      0x00
+
+#endif
+
+#define SAR_ADC_RUNING_MODE_GAIN0   0x01
+#define SAR_ADC_RUNING_MODE_GAIN1   0x02
+#define SAR_ADC_RUNING_MODE_GAIN2   0x04
+
+#define SAR_ADC_RUNING_MODE_ALL     (SAR_ADC_RUNING_MODE_GAIN0|SAR_ADC_RUNING_MODE_GAIN1|SAR_ADC_RUNING_MODE_GAIN2)
+
+enum sar_adc_mode {
+    FTSAR_ADC_KEYDET_MODE,
+    FTSAR_ADC_DRYBAT_MODE,
+    FTSAR_ADC_LIBAT_MODE
+};
+
+struct scu_t {
+    int fd;
+    int (*register_scu)(int* scu_fd);
+    int (*deregister_scu)(int* scu_fd);
+};
+
+struct flp_data {	
+    /* generic attributes */
+	struct dev_data* p_dev_data;
+    unsigned int buffer_size;
+    void* buffer_vadr;
+    void* buffer_padr;
+
+};
+
+/* dev specific define */
+struct dev_specific_data_t {
+    unsigned long   scan_duration;
+    int             last_key_sts;
+    unsigned long   last_scan_jiffies;
+    
+    spinlock_t      lock;
+    struct kfifo    fifo;
+    int             queue_len;
+    wait_queue_head_t   wait_queue;
+    struct delayed_work key_work;
+    struct semaphore    oper_sem;
+    unsigned short      xgain0_min;
+    unsigned short      xgain0_max;
+	unsigned short      xgain0_int;
+};
+
+struct dev_data {
+    
+    /* generic attributes */
+    struct cdev 				cdev;          /* chrdev */
+    struct class*				class;
+    struct device*				p_device;
+    dev_t 						dev_num;
+    
+    int 						id;            /* platform_device id */   
+    
+    unsigned int 				io_size;       /* IP reg size, be set after platform_get_resource */    
+    void* 						io_vadr;       /* IP io_vadr */        
+    void* 						io_padr;       /* IP io_padr */    
+    
+    int 						irq_no;        /* IP irq number */    
+    struct scu_t 				scu;           /* pmu */        
+    unsigned int 				driver_count;  /* driver ref count */
+    unsigned int                running_mode;  /* SARADC running mode for gain 1,2,3*/
+    /* specific attributes */    
+	struct dev_specific_data_t  dev_specific_data; 
+    
+};
+#endif

--- a/arch/arm/mach-GM/sar-adc-drv/gm8136.c
+++ b/arch/arm/mach-GM/sar-adc-drv/gm8136.c
@@ -1,0 +1,852 @@
+/*
+ * Revision History
+ * 2013/11/27 prevent CVBS jitter for read saradc REG 2
+ * 2013/12/13 support runing mode for 8139
+ */
+#include "platform.h"                                                                                                                                                     
+#include "sar_adc_drv.h"                                                                                                                                                  
+#include "sar_adc_dev.h"                                                                                                                                                  
+#include <mach/ftpmu010.h>                                                                                                                                                
+#include <linux/delay.h>                                                                                                                                                  
+#include <linux/kthread.h>
+
+#define PRINT_E(args...) do { printk(args); }while(0)                                                                                                                     
+#define PRINT_I(args...) do { printk(args); }while(0)                                                                                                                     
+                                                                                                                                                                          
+#define PLL_CLK          0xB8                                                                                                                                             
+#define PLL_CLK_BIT     (0x1<<8 )  /* ADC*/                                                                                                                                        
+                                                                                                                                                                          
+#define GATE_CLK	     0xAC                                                                                                                                     
+#define GATE_CLK_BIT	(0x1 << 3)/*  bit3 is SAR ADC */                                                                                          
+
+#define CLOCK_DIVID_BIT  0x003F0000
+static int scu_fd;
+
+#define POLLING_DELAY  200
+#define ADDA_PLUG_AUTO 0x00
+#define ADDA_PLUG_IN   0x01
+#define ADDA_PLUG_OUT  0x02
+
+#define HW_ENABLE_XGAIN   (0x7)
+#define HW_XGAIN_MASK     ((0x03 << 20|0x1<<15|0x1<<16 |0x1<<9|0x1<<10)|HW_ENABLE_XGAIN)
+#define HW_ENABLE_XGAIM_0 (0x1)
+#define HW_ENABLE_XGAIM_1 (0x1<<1)
+#define HW_ENABLE_XGAIM_2 (0x1<<2)	
+
+#define SW_XGAIN_MASK     (0x7|0x03 << 20|0x1<<15|0x1<<16 |0x1<<9|0x1<<10 |0x3<<6)
+#define SW_ENABLE_XGAIM_0 (0x1<<19|0x1<<20)
+#define SW_ENABLE_XGAIM_1 (0x1<<19|0x2<<20)
+#define SW_ENABLE_XGAIM_2 (0x1<<19|0x3<<20)
+
+#define XGAIN0_INT_ENABLE  (0x1<<15|0x1<<16|0x1<<9|0x1<<10)
+
+#define ADC_POWERDOWN_EN  (0x0 << 8) 
+#define ADC_POWERDOWN_DIS  (0x1 << 8) 
+
+#define CVBS_PLUG_REPEAT_TIME      2
+
+#define HW_EOC_DROP_COUNTER (0x2<<3) //BIT3~5 always set 2
+
+#define SW_EOC_DROP_COUNTER (0x1<<3) //BIT3~5 always set 1
+
+#define GAINO_INT_DEFAULT_MAX_TH      0x15 //21
+
+struct timer_list xain_change_timer;                                                                                                                                                                          
+/* *INDENT-OFF* */                                                                                                                                                        
+static pmuReg_t pmu_reg[] = {                                                                                                                                             
+/*  {reg_off,   bits_mask,     lock_bits,    init_val,    init_mask } */                                                                                                  
+    {PLL_CLK,   PLL_CLK_BIT,   PLL_CLK_BIT,      0x0,      PLL_CLK_BIT }, // ADC clock selection                                                                          
+    {GATE_CLK,  GATE_CLK_BIT,  GATE_CLK_BIT, 	 0x0<<3,   0x1<< 3}, // Enable ADC 
+    {0x74,  CLOCK_DIVID_BIT,  CLOCK_DIVID_BIT, 	 (0x27 << 16), CLOCK_DIVID_BIT },//30MHZ /40 = 750khz
+};                                                                                                                                                                        
+                                                                                                                                                                          
+static pmuRegInfo_t pmu_reg_info = {                                                                                                                                      
+    DEV_NAME,                                                                                                                                                             
+    ARRAY_SIZE(pmu_reg),                                                                                                                                                  
+    ATTR_TYPE_NONE,                                                                                                                                                       
+    pmu_reg,                                                                                                                                                              
+};                                                                                                                                                                        
+
+static struct task_struct *saradc_thread = NULL;
+static volatile int saradc_thread_runing = 0;
+struct semaphore    polling_sem; /*spec for 8139 usage*/
+
+static volatile unsigned int g_tv100_base = 0;
+static volatile unsigned int g_adda_base = 0;
+
+static int  polling_process_is_init = 0;
+static int  g_saradc_cvbs_info = ADDA_PLUG_OUT;/*0 :init ,1 : plug in ,2:plug out*/
+static int  g_saradc_debug = 0;/*1 : xgain1 ,2:xgain2 */
+static int  g_saradc_forcecvbs = ADDA_PLUG_AUTO;/*0 :init ,1 : plug in ,2:plug out*/
+static unsigned int  g_cvbs_on_tsr = HW_OUTPUT_VOL_THR_ON;
+static unsigned int  g_cvbs_off_tsr = HW_OUTPUT_VOL_THR_OFF;
+static u32 g_polling_time = POLLING_DELAY;
+
+static u32 g_gain_mask = 0;
+static u32 g_xgain0_en = 0;
+static u32 g_xgain1_en = 0;
+static u32 g_xgain2_en = 0;
+static u32 g_eoc_drop  = 0;
+static u32 g_base_set  = 0;
+static u32 g_base_gain2_set  = 0x09000100;
+
+extern  u32    g_recovery_cnt;
+extern  unsigned int poll_mode;
+extern  unsigned short auto_interval[3];
+/************************************/
+void Platform_Set_ADDA_TVBS(int enable);
+
+/**********************************/
+int register_scu(void)                                                                                                                                                    
+{                                                                                                                                                                         
+    scu_fd = ftpmu010_register_reg(&pmu_reg_info);                                                                                                                        
+    if (scu_fd < 0) {                                                                                                                                                     
+        printk("Failed to register %s scu\n", DEV_NAME);                                                                                                                  
+        return -1;                                                                                                                                                        
+    }                                                                                                                                                                     
+    return 0;                                                                                                                                                             
+}                                                                                                                                                                         
+                                                                                                                                                                          
+                                                                                                                                                                          
+int deregister_scu(void)                                                                                                                                                  
+{                                                                                                               
+    int ret = 0;                                                                                                                                                   
+                                                                                                                                    
+                                                                                                                                                                          
+    if (unlikely((ret = ftpmu010_write_reg(scu_fd, GATE_CLK ,0x1 << 3, GATE_CLK_BIT))!= 0))
+	{
+	    PRINT_E("saradc %s set as 0x%08X fail\n", __func__, GATE_CLK);                                                                                                        
+    }   
+	
+    if (scu_fd >= 0) {                                                                                                                                                    
+        if (ftpmu010_deregister_reg(scu_fd)) {                                                                                                                            
+            printk("Failed to deregister %s scu\n", DEV_NAME);                                                                                                            
+            scu_fd = -1;                                                                                                                                                  
+            return -1;                                                                                                                                                    
+        }                                                                                                                                                                 
+    }                                                                                                                                                                     
+    return 0;                                                                                                                                                             
+}                                                                                                                                                                         
+                                                                                                                                                                          
+int scu_probe(struct scu_t *p_scu)                                                                                                                                        
+{                                                                                                                                                                         
+    if (unlikely(register_scu() < 0))                                                                                                                                     
+    {                                                                                                                                                                     
+        printk("register_scu errr\n");                                                                                                                                    
+        return -1;                                                                                                                                                        
+    }
+
+    g_adda_base = (unsigned int) ioremap_nocache ((uint32_t)ADDA_PA_START,(ADDA_PA_END -  ADDA_PA_START +1));
+    g_tv100_base = (unsigned int)ioremap_nocache(TVE_FTTVE100_PA_BASE, TVE_FTTVE100_PA_SIZE);
+    printk(" * ADDA paddr=%x vaddr=%x tve paddr=%x vaddr=%x\n",ADDA_PA_START,g_adda_base,TVE_FTTVE100_PA_BASE,g_tv100_base);
+    return 0;                                                                                                                                                             
+}                                                                                                                                                                         
+                                                                                                                                                                          
+int scu_remove(struct scu_t *p_scu)                                                                                                                                       
+{                                                                                                                                                                         
+    int ret;                                                                                                                                                              
+                                                                                                                                                                          
+    ret = deregister_scu();  
+
+     __iounmap((void *)g_adda_base);
+    g_adda_base = 0;
+    __iounmap((void *)g_tv100_base);
+    g_tv100_base = 0;
+    
+    return ret;                                                                                                                                                           
+}                                                                                                                                                                         
+                                                                                                                                                                          
+int set_pinmux(void)                                                                                                                                                      
+{                                                                                                                                                                         
+    unsigned int pmu_mfps = ftpmu010_read_reg(PLL_CLK);                                                                                                               
+    int ret = 0;                                                                                                                                                      
+                                                                                                                                                                          
+    pmu_mfps &= ~(PLL_CLK_BIT);                                                                                                                                       
+                                                                                                                                                                          
+    if (unlikely((ret = ftpmu010_write_reg(scu_fd, PLL_CLK , 0, PLL_CLK_BIT))!= 0))
+    {
+	    PRINT_E("%s set as 0x%08X\n", __func__, pmu_mfps);                                                                                                        
+    }                                                                                                                                                                 
+    pmu_mfps = ftpmu010_read_reg(PLL_CLK);                                                                                                                            
+    PRINT_I(" * %s set as 0x%02X 0x%08X OK\n", __func__, PLL_CLK, pmu_mfps);
+    return ret;                                                                                                                                                           
+}
+#if 1
+static void _platform_process_xgain0_value(struct dev_data* p_dev_data)
+{
+    unsigned int vbase = (unsigned int)p_dev_data->io_vadr;
+    struct dev_specific_data_t* p_data  = (struct dev_specific_data_t*)&p_dev_data->dev_specific_data;
+    unsigned int adc_val;
+    int          len;
+    sar_adc_pub_data new_data;
+    
+    adc_val=SAR_ADC_RAW_REG_RD(vbase,FTSAR_ADC_DAT0);
+    if(g_saradc_debug)
+        printk("xgain0_value = %d\n",adc_val);
+    
+    if(adc_val == 0)
+        return;
+
+    new_data.adc_val = adc_val;
+    new_data.status  = KEY_XAIN_0;
+
+    Platform_Lock_Polling_Mutex();
+    
+    len = kfifo_in(
+		&p_data->fifo, 
+		&new_data,
+		sizeof(sar_adc_pub_data)
+		);
+    
+    Platform_UnLock_Polling_Mutex();
+
+	wake_up(&p_data->wait_queue);
+	
+     if(len < sizeof(sar_adc_pub_data)){
+		if(g_saradc_debug)
+        	printk("put data into fifo queue fail (GAIN0)\n");
+    }
+     
+}
+#endif
+static void _platform_process_xgain1_value(struct dev_data* p_dev_data)
+{
+    unsigned int vbase = (unsigned int)p_dev_data->io_vadr;
+    struct dev_specific_data_t* p_data  = (struct dev_specific_data_t*)&p_dev_data->dev_specific_data;
+    unsigned int adc_val;
+    int          len;
+    sar_adc_pub_data new_data;
+    
+    adc_val=SAR_ADC_RAW_REG_RD(vbase,FTSAR_ADC_DAT1);
+    if(g_saradc_debug)
+        printk("xgain1_value = %d\n",adc_val);
+    
+    if(adc_val == 0)
+        return;
+
+    new_data.adc_val = adc_val;
+    new_data.status  = KEY_XAIN_1;
+
+    Platform_Lock_Polling_Mutex();
+    
+    len = kfifo_in(
+		&p_data->fifo, 
+		&new_data,
+		sizeof(sar_adc_pub_data)
+		);
+    
+    Platform_UnLock_Polling_Mutex();
+
+	wake_up(&p_data->wait_queue);
+	
+    if(len < sizeof(sar_adc_pub_data)){
+        if(g_saradc_debug)
+            printk("put data into fifo queue fail \n");
+    }
+     
+}
+static int sar_adc_reset(struct dev_data *p_dev_data)
+{
+	/**/                                                                                                                                 
+    u32         base_addr = 0 ; 	
+	int   val = 0;
+	/*power down*/
+	base_addr = (u32)p_dev_data->io_vadr;
+
+	val = SAR_ADC_RAW_REG_RD(base_addr, FTSAR_ADC_CR0);
+
+	val &= ~(ADC_POWERDOWN_DIS);
+	val &= ~(HW_ENABLE_XGAIM_0|HW_ENABLE_XGAIM_1|HW_ENABLE_XGAIM_2);
+	
+	SAR_ADC_RAW_REG_WR(base_addr, FTSAR_ADC_CR0, val); 	
+    msleep(100);
+	/*enable hw chanel 0*/
+	val |= (ADC_POWERDOWN_DIS);
+	val |= HW_ENABLE_XGAIM_0;
+	
+	SAR_ADC_RAW_REG_WR(base_addr, FTSAR_ADC_CR0, val); 
+	msleep(100);
+	/*enable hw chanel 1*/
+	val &= ~(HW_ENABLE_XGAIM_0|HW_ENABLE_XGAIM_1|HW_ENABLE_XGAIM_2);
+	val |= HW_ENABLE_XGAIM_1;
+	
+	SAR_ADC_RAW_REG_WR(base_addr, FTSAR_ADC_CR0, val); 
+	msleep(10);
+	/*enable hw chanel 2*/
+	val &= ~(HW_ENABLE_XGAIM_0|HW_ENABLE_XGAIM_1|HW_ENABLE_XGAIM_2);
+	val |= HW_ENABLE_XGAIM_2;
+	
+	SAR_ADC_RAW_REG_WR(base_addr, FTSAR_ADC_CR0, val); 
+	msleep(100);
+
+	/*enable all*/
+	val &= ~(HW_ENABLE_XGAIM_0|HW_ENABLE_XGAIM_1|HW_ENABLE_XGAIM_2);
+	val |= (p_dev_data->running_mode&0x7);
+	
+	SAR_ADC_RAW_REG_WR(base_addr, FTSAR_ADC_CR0, val); 
+	msleep(100);
+	
+	g_recovery_cnt++;
+    //printk("saradr reset v2.6!!!\n");
+	
+	return 0;
+}
+
+static void change_detect_xain(struct dev_data* data)                                                                                                                        
+{                                                                                                                                                                         
+    struct dev_data *p_dev_data = (struct dev_data*)data;                                                                                                             
+    unsigned int base = (unsigned int)p_dev_data->io_vadr;                                                                                                            
+	                                                                                                                                                                  
+    static int xain_num=0;                                                                                                                                                
+    unsigned int val,ran_flag = 0;
+    
+    val = SAR_ADC_RAW_REG_RD( base, FTSAR_ADC_CR0);
+    
+    do{
+        switch(xain_num){
+            case 0:
+				if(poll_mode){
+					if(p_dev_data->running_mode & SAR_ADC_RUNING_MODE_GAIN0){
+	                    //val &= ~g_gain_mask; 
+						if(p_dev_data->dev_specific_data.xgain0_int){
+							val = (g_xgain0_en|g_base_set |g_eoc_drop);
+							
+							SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_CR0, val);	
+						}
+						else{
+	                    	val = (g_xgain0_en|g_eoc_drop|g_base_set); 
+	                    	
+		                    SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_CR0, val);		
+							mdelay(1);
+							_platform_process_xgain0_value(p_dev_data);
+						}
+	                    xain_num = 1;
+	                    ran_flag = 1;                   
+	                }
+	                else{
+	                    xain_num = 1;
+	                    ran_flag = 0;         
+	                }
+				}else{
+	                if(p_dev_data->running_mode & SAR_ADC_RUNING_MODE_GAIN0){
+	                    //val &= ~g_gain_mask; 
+						if(p_dev_data->dev_specific_data.xgain0_int){
+							//val = (g_xgain0_en|g_base_set |g_eoc_drop);
+							//val = (g_base_set |g_eoc_drop);
+							//SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_CR0, val);	
+						}
+						else{
+	                    	//val = (g_xgain0_en|g_eoc_drop|g_base_set); 
+	                    	//val = (g_eoc_drop|g_base_set); 
+		                    //SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_CR0, val);		
+							mdelay(1);
+							_platform_process_xgain0_value(p_dev_data);
+						}
+	                    xain_num = 1;
+	                    ran_flag = 1;                   
+	                }
+	                else{
+	                    xain_num = 1;
+	                    ran_flag = 0;         
+	                }
+				}
+                break;
+            case 1:
+				if(poll_mode){
+					if(p_dev_data->running_mode & SAR_ADC_RUNING_MODE_GAIN1){
+	                    //val &= ~g_gain_mask; 
+	                    val = (g_xgain1_en|g_eoc_drop|g_base_set);
+	                    //val = (g_eoc_drop|g_base_set);
+	                    SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_CR0, val);
+	                    mdelay(1);
+	                    _platform_process_xgain1_value(p_dev_data);
+	                    xain_num = 2;
+	                    ran_flag = 1;                  
+	                }
+	                else{
+	                    xain_num = 2;
+	                    ran_flag = 0;                  
+	                }
+				}else{
+	                if(p_dev_data->running_mode & SAR_ADC_RUNING_MODE_GAIN1){
+	                    //val &= ~g_gain_mask; 
+	                    //val = (g_xgain1_en|g_eoc_drop|g_base_set);
+	                    //val = (g_eoc_drop|g_base_set);
+	                    //SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_CR0, val);
+	                    mdelay(1);
+	                    _platform_process_xgain1_value(p_dev_data);
+	                    xain_num = 2;
+	                    ran_flag = 1;                  
+	                }
+	                else{
+	                    xain_num = 2;
+	                    ran_flag = 0;                  
+	                }
+				}
+                break;
+            case 2:
+#if 1			
+				/*SW mode don't care cvbs*/
+				if(poll_mode){
+					xain_num = 0;
+                    ran_flag = 0;  
+				}else{
+	                if(p_dev_data->running_mode & SAR_ADC_RUNING_MODE_GAIN2){
+	                    //val &= ~g_gain_mask; 
+	                    //val = (g_xgain2_en|g_eoc_drop|g_base_gain2_set);  
+	                    //val = (g_eoc_drop|g_base_gain2_set);  
+	                    //SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_CR0, val);
+	                    mdelay(1);
+	                    Platform_Process_Volt_Threshold(p_dev_data);
+	                    xain_num = 0;
+	                    ran_flag = 1;                   
+	                }
+	                else{
+	                    xain_num = 0;
+	                    ran_flag = 0;                    
+	                }
+				}
+#endif				
+                break;
+            default:
+                printk("%s unexpected case\n",__func__);
+                break;
+        }
+    }while(!ran_flag);
+                                                                                                                        
+} 
+
+static int saradc_polling_thread(void *private)
+{
+    struct dev_data *p_dev_data = (struct dev_data*)private;
+    saradc_thread_runing = 1;
+
+    /*First time set adda and tvbs down*/
+    Platform_Set_ADDA_TVBS(0);
+    
+    do {
+        
+        change_detect_xain(p_dev_data);
+        msleep(g_polling_time);
+        
+    }while(!kthread_should_stop());
+    
+    saradc_thread_runing = 0;
+    return 0;
+}
+
+void Platform_Set_Init_Reg(struct dev_data *p_dev_data)                                                                                                                   
+{ 
+    unsigned int val;                                                                                                                                                 
+    unsigned int base = (unsigned int)p_dev_data->io_vadr;
+#if 1
+
+    unsigned char lmin=0,lmax=0;
+ 	
+    lmin = p_dev_data->dev_specific_data.xgain0_min & 0xff;
+	lmax = p_dev_data->dev_specific_data.xgain0_max & 0xff; 
+	
+	if(lmax == 0)
+		lmax = GAINO_INT_DEFAULT_MAX_TH;
+    
+    val = (lmax << 16)| lmin;/* set high threshold as 0x00010001 */                                                                                                                 
+    SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_THD0, val);
+
+#endif
+    val = SAR_ADC_RAW_REG_RD(g_adda_base, ADDA_DAC_REG);                                                                                                                
+    val |= 0x10;                                                                                                                                                      
+    SAR_ADC_RAW_REG_WR( g_adda_base, ADDA_DAC_REG, val); 
+	
+    //val= SAR_ADC_RAW_REG_RD(base, FTSAR_ADC_CR0);
+    //val = 0x0B018701;    
+    //val = 0x0B187F00|EOC_DROP_COUNTER; /*xgain 0 enable interrupt , xgain_1 xgain_2 polling mode*/
+    
+	if(!poll_mode){
+		g_gain_mask = HW_XGAIN_MASK;
+		g_xgain0_en = HW_ENABLE_XGAIM_0;
+		g_xgain1_en = HW_ENABLE_XGAIM_1;
+		g_xgain2_en = HW_ENABLE_XGAIM_2;
+		g_eoc_drop  = HW_EOC_DROP_COUNTER;
+		g_cvbs_on_tsr = HW_OUTPUT_VOL_THR_ON;
+        g_cvbs_off_tsr = HW_OUTPUT_VOL_THR_OFF;
+		g_saradc_forcecvbs = ADDA_PLUG_AUTO;
+	
+		if(p_dev_data->dev_specific_data.xgain0_int){
+			
+			val = 0x09018700|HW_EOC_DROP_COUNTER|(p_dev_data->running_mode&0x7);/*xgain 0 enable interrupt , xgain_1 xgain_2 polling mode*/			
+			g_base_set = val;
+		}	
+		else{
+			val = 0x09000100|HW_EOC_DROP_COUNTER|(p_dev_data->running_mode&0x7) ;
+			g_base_set = val; 
+		}
+
+		g_base_gain2_set = g_base_gain2_set | (p_dev_data->running_mode&0x7) ;
+		SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_AUTO_REQ0, auto_interval[0]);//50us
+		SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_AUTO_REQ1, auto_interval[1]);//100us
+		SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_AUTO_REQ2, auto_interval[2]);//frame base
+
+		
+	}
+	else{
+		g_gain_mask = SW_XGAIN_MASK;
+		g_xgain0_en = SW_ENABLE_XGAIM_0;
+		g_xgain1_en = SW_ENABLE_XGAIM_1;
+		g_xgain2_en = SW_ENABLE_XGAIM_2;
+		g_eoc_drop  = SW_EOC_DROP_COUNTER;
+		g_cvbs_on_tsr = SW_OUTPUT_VOL_THR_ON;
+        g_cvbs_off_tsr =SW_OUTPUT_VOL_THR_OFF;
+		g_saradc_forcecvbs = ADDA_PLUG_OUT;
+		if(p_dev_data->dev_specific_data.xgain0_int){
+			val = 0x09098700|SW_EOC_DROP_COUNTER;/*xgain 0 enable interrupt , xgain_1 xgain_2 polling mode*/
+			g_base_set = val;
+			g_base_gain2_set = val;
+		}
+		else{
+			val = 0x09080100|SW_EOC_DROP_COUNTER ; //0x0b480100
+			g_base_set = val;
+			g_base_gain2_set = val;
+		}
+		
+		SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_AUTO_REQ0, 0x0);//50ms
+		SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_AUTO_REQ1, 0x0);//100ms
+		SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_AUTO_REQ2, 0x0);//30ms
+			
+	}
+	SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_CR0, val); 	
+    udelay(50);
+
+	//sw polling set cvbs as zero
+	if(poll_mode)
+		Platform_Force_Set_ADDA_TVBS(0);	
+}
+                                                                                                                                                                          
+int Platform_Init_Pollign_Timer(struct dev_data *p_dev_data)                                                                                                             
+{    
+    init_MUTEX(&polling_sem);
+    
+    saradc_thread = kthread_create(saradc_polling_thread, (void*)p_dev_data, "saradc thread");
+    if (IS_ERR(saradc_thread)){
+        printk("SARADC: Error in creating kernel thread! \n");
+        return -1;
+    }
+
+    wake_up_process(saradc_thread); 
+    polling_process_is_init = 1;
+    return 0;
+}                                                                                                                                                                         
+                                                                                                                                                                          
+void Platform_Del_Pollign_Timer(void)                                                                                                                                     
+{
+    unsigned int val;
+    
+    if (saradc_thread)
+        kthread_stop(saradc_thread);
+    
+    while (saradc_thread_runing == 1)
+        msleep(1);
+    
+    /* turn on ADDA wrapper
+     */
+    /* 1. video_dac_stby low */
+    val = SAR_ADC_RAW_REG_RD(g_adda_base, ADDA_DAC_REG);                                                                                                                
+    val &= ~(0x1 << 3);
+    /* 2. PD, PSW_PD, ISO_ENABLE */
+    val &= ~(0x7); 
+    SAR_ADC_RAW_REG_WR(g_adda_base, ADDA_DAC_REG, val); 
+
+    /* turn on TVE100
+     */
+    val = SAR_ADC_RAW_REG_RD(g_tv100_base, TVE_POWER_DOWN_REG);
+    val &= ~(0x7);
+    SAR_ADC_RAW_REG_WR(g_tv100_base,TVE_POWER_DOWN_REG,val);   
+}                                                                                                                                                                         
+                                                                                                                                                                          
+void Platform_Process_Volt_Threshold(struct dev_data *p_dev_data)                                                                                    
+{
+    unsigned int vbase = (unsigned int)p_dev_data->io_vadr; 
+    unsigned int adc_val ,val; 
+    static int  out_detect_count = 0  ,int_detect_count = 0;
+	static int  zero_val = 0;
+        
+    adc_val=SAR_ADC_RAW_REG_RD(vbase,FTSAR_ADC_DAT2);
+
+    if(g_saradc_debug)
+        printk("Platform_Process_Volt_Threshold=%d-%d-%d\n",adc_val,g_saradc_cvbs_info,g_saradc_forcecvbs);
+
+    if(adc_val == 0 ){
+		zero_val++;
+		if(zero_val == 15){
+			zero_val = 0;
+			sar_adc_reset(p_dev_data);
+		}
+        return;
+    }
+
+    if(g_saradc_forcecvbs != ADDA_PLUG_AUTO){
+        return;
+    }
+
+    if(g_saradc_cvbs_info == ADDA_PLUG_IN && adc_val > g_cvbs_on_tsr){                                                                                                                                
+        out_detect_count++;
+        if(out_detect_count  < CVBS_PLUG_REPEAT_TIME){
+         
+            return;
+        }
+        out_detect_count = 0;
+        int_detect_count = 0;
+        printk(KERN_DEBUG "plug-out=%x\n",adc_val);
+        g_saradc_cvbs_info = ADDA_PLUG_OUT;
+        //pre_adda_status = ADDA_PLUG_OUT;
+        /* turn off ADDA wrapper
+         */
+        /* 1. set ISO enable */
+        val = SAR_ADC_RAW_REG_RD(g_adda_base, ADDA_DAC_REG);                                                                                                                
+        val |= (0x1);
+        SAR_ADC_RAW_REG_WR( g_adda_base, ADDA_DAC_REG, val); 
+        /* 2. PD, PSW_PD */
+        val |= (0x6); 
+        SAR_ADC_RAW_REG_WR( g_adda_base, ADDA_DAC_REG, val);
+
+        /* turn off TVE100
+         */
+        val = SAR_ADC_RAW_REG_RD(g_tv100_base, TVE_POWER_DOWN_REG);
+        val |= (0x7);
+        SAR_ADC_RAW_REG_WR(g_tv100_base,TVE_POWER_DOWN_REG,val); 
+  
+    }
+    else if(g_saradc_cvbs_info == ADDA_PLUG_OUT && adc_val < g_cvbs_off_tsr){ 
+        int_detect_count++;
+        if(int_detect_count  < CVBS_PLUG_REPEAT_TIME){
+            return;
+        }
+        int_detect_count = 0;
+        out_detect_count = 0;
+        printk(KERN_DEBUG "plug-in=%x\n",adc_val);
+        //pre_adda_status = ADDA_PLUG_IN;
+        g_saradc_cvbs_info = ADDA_PLUG_IN;
+        /* turn on ADDA wrapper
+         */
+        /* 1. video_dac_stby low */
+        val = SAR_ADC_RAW_REG_RD(g_adda_base, ADDA_DAC_REG);                                                                                                                
+        val &= ~(0x1 << 3);
+        SAR_ADC_RAW_REG_WR( g_adda_base, ADDA_DAC_REG, val);
+        /* 2. PD, PSW_PD, ISO_ENABLE */
+        val &= ~(0x7); 
+        SAR_ADC_RAW_REG_WR( g_adda_base, ADDA_DAC_REG, val); 
+
+        /* turn on TVE100
+         */
+        val = SAR_ADC_RAW_REG_RD(g_tv100_base, TVE_POWER_DOWN_REG);
+        val &= ~(0x7);
+        SAR_ADC_RAW_REG_WR(g_tv100_base,TVE_POWER_DOWN_REG,val);  
+		
+    }
+    else if(g_saradc_cvbs_info == ADDA_PLUG_IN && adc_val <= g_cvbs_on_tsr){
+        int_detect_count = 0;
+        out_detect_count = 0;
+    }
+    else if(g_saradc_cvbs_info == ADDA_PLUG_OUT && adc_val >= g_cvbs_off_tsr){
+        int_detect_count = 0;
+        out_detect_count = 0;
+    }
+    else {
+        if(g_saradc_debug)
+            printk("Uknow state=%d-%d\n",adc_val,g_saradc_cvbs_info);
+    }
+
+} 
+int Platform_SAR_ADC_GetData(struct dev_data *p_dev_data , sar_adc_pub_data* new_data)
+{
+    unsigned int base = (unsigned int)p_dev_data->io_vadr;
+    unsigned int value;
+
+    value=SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT0);
+
+    if(g_saradc_debug)
+        printk("xgain0_value = %d\n",value);
+      
+    if(value > 0x0) {
+        new_data->adc_val = value;
+        new_data->status = KEY_XAIN_0;
+        return 0;
+    }
+#if 0 
+
+    value = SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT1);
+    if(value > 0x0) {
+        new_data->adc_val = value;
+        new_data->status = KEY_XAIN_1;
+        return 0;
+    }
+   
+    value=SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT2); 
+    if(value > 0x0) {
+        new_data->adc_val = value;
+        new_data->status = KEY_XAIN_2;
+        return 0;
+    }
+#endif    
+    new_data->adc_val = 0;
+    new_data->status = 0;
+    return -1;
+}
+
+int Platform_Set_Polling_Time(unsigned int time_val)
+{
+   
+    if(time_val == 0)
+        return -1;
+    
+    g_polling_time =  time_val;
+   
+    return 0;
+}
+
+u32 Platform_Get_Polling_Time(void)
+{
+    return g_polling_time;
+}
+
+
+int Platform_Set_CVBS_THR_Value(unsigned int on_vlaue,unsigned int off_value)
+{
+    if(on_vlaue >= OUTPUT_VOL_THR_TOP || on_vlaue <= OUTPUT_VOL_THR_DOWN
+       || off_value >= OUTPUT_VOL_THR_TOP || off_value <= OUTPUT_VOL_THR_DOWN)
+       return -1;
+    
+    g_cvbs_on_tsr =  on_vlaue;
+    g_cvbs_off_tsr = off_value;
+    return 0;
+}
+
+int Platform_Get_CVBS_THR_Value(unsigned int *on_vlaue,unsigned int *off_value)
+{
+    if(on_vlaue == NULL || off_value == NULL)
+        return -1;
+   
+    *on_vlaue = g_cvbs_on_tsr;
+    *off_value = g_cvbs_off_tsr;
+    
+    return 0;
+}
+
+void Platform_Set_ADDA_TVBS(int enable)
+{
+    unsigned int val = 0;
+    if(enable)
+    {
+        /* turn on ADDA wrapper
+         */
+        /* 1. video_dac_stby low */
+        val = SAR_ADC_RAW_REG_RD(g_adda_base, ADDA_DAC_REG);                                                                                                                
+        val &= ~(0x1 << 3);
+        SAR_ADC_RAW_REG_WR( g_adda_base, ADDA_DAC_REG, val);
+        /* 2. PD, PSW_PD, ISO_ENABLE */
+        val &= ~(0x7); 
+        SAR_ADC_RAW_REG_WR( g_adda_base, ADDA_DAC_REG, val); 
+
+        /* turn on TVE100
+         */
+        val = SAR_ADC_RAW_REG_RD(g_tv100_base, TVE_POWER_DOWN_REG);
+        val &= ~(0x7);
+        SAR_ADC_RAW_REG_WR(g_tv100_base,TVE_POWER_DOWN_REG,val);      
+    }else{
+        /* turn off ADDA wrapper
+         */
+        /* 1. set ISO enable */
+        val = SAR_ADC_RAW_REG_RD(g_adda_base, ADDA_DAC_REG);                                                                                                                
+        val |= (0x1);
+        SAR_ADC_RAW_REG_WR( g_adda_base, ADDA_DAC_REG, val); 
+        /* 2. PD, PSW_PD */
+        val |= (0x6); 
+        SAR_ADC_RAW_REG_WR( g_adda_base, ADDA_DAC_REG, val);
+
+        /* turn off TVE100
+         */
+        val = SAR_ADC_RAW_REG_RD(g_tv100_base, TVE_POWER_DOWN_REG);
+        val |= (0x7);
+        SAR_ADC_RAW_REG_WR(g_tv100_base,TVE_POWER_DOWN_REG,val); 
+    }
+}
+
+int Platform_Force_Set_ADDA_TVBS(int force)
+{
+    if(force == ADDA_PLUG_IN && g_saradc_forcecvbs != ADDA_PLUG_IN){
+        Platform_Set_ADDA_TVBS(1);
+        g_saradc_forcecvbs = ADDA_PLUG_IN;
+        g_saradc_cvbs_info = ADDA_PLUG_IN;
+    }
+    else if(force == ADDA_PLUG_OUT && g_saradc_forcecvbs != ADDA_PLUG_OUT){
+        Platform_Set_ADDA_TVBS(0);
+        g_saradc_forcecvbs = ADDA_PLUG_OUT;
+        g_saradc_cvbs_info = ADDA_PLUG_OUT;
+    }
+    else if(force == ADDA_PLUG_AUTO && g_saradc_forcecvbs != ADDA_PLUG_AUTO){
+        g_saradc_forcecvbs = ADDA_PLUG_AUTO;
+    }
+    return 0;
+}
+
+int Platform_Force_Get_ADDA_TVBS(void)
+{
+    return  g_saradc_forcecvbs;   
+}
+
+int Platform_Get_CVBS_Info(void)
+{
+    return g_saradc_cvbs_info;
+}
+
+int Platform_Get_SARADC_Debug(void)
+{
+    return g_saradc_debug;
+}
+
+void Platform_Set_SARADC_Debug(int value)
+{
+    g_saradc_debug = value;
+}
+
+int Platform_Get_Polling_Timer_State(void)
+{
+    if(polling_process_is_init)
+        return 1;
+    return 0;
+}
+
+void Platform_Lock_Polling_Mutex(void)
+{
+    down(&polling_sem);    
+}
+
+void Platform_UnLock_Polling_Mutex(void)
+{
+    up(&polling_sem);    
+}
+
+int Platform_Check_Support_XGain(int num)
+{
+    if(num >=0 && num <= 2)
+        return 0;
+    return -1;    
+}
+unsigned int Platform_Direct_Get_XGain_Value(unsigned int base , int num)
+{
+    unsigned int value = 0;
+    
+    if(num == 0){
+        value=SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT0);       
+    }
+
+    if(num == 1){
+        value=SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT1);
+    }
+
+    if(num == 2){
+        value=SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT2);
+       
+    }
+    return value;
+}
+

--- a/arch/arm/mach-GM/sar-adc-drv/gm8139.c
+++ b/arch/arm/mach-GM/sar-adc-drv/gm8139.c
@@ -1,0 +1,852 @@
+/*
+ * Revision History
+ * 2013/11/27 prevent CVBS jitter for read saradc REG 2
+ * 2013/12/13 support runing mode for 8139
+ */
+#include "platform.h"                                                                                                                                                     
+#include "sar_adc_drv.h"                                                                                                                                                  
+#include "sar_adc_dev.h"                                                                                                                                                  
+#include <mach/ftpmu010.h>                                                                                                                                                
+#include <linux/delay.h>                                                                                                                                                  
+#include <linux/kthread.h>
+
+#define PRINT_E(args...) do { printk(args); }while(0)                                                                                                                     
+#define PRINT_I(args...) do { printk(args); }while(0)                                                                                                                     
+                                                                                                                                                                          
+#define PLL_CLK          0xB8                                                                                                                                             
+#define PLL_CLK_BIT     (0x1<<8 )  /* ADC*/                                                                                                                                        
+                                                                                                                                                                          
+#define GATE_CLK	     0xAC                                                                                                                                     
+#define GATE_CLK_BIT	(0x1 << 3)/*  bit3 is SAR ADC */                                                                                          
+
+#define CLOCK_DIVID_BIT  0x003F0000
+static int scu_fd;
+
+#define POLLING_DELAY  200
+#define ADDA_PLUG_AUTO 0x00
+#define ADDA_PLUG_IN   0x01
+#define ADDA_PLUG_OUT  0x02
+
+#define HW_ENABLE_XGAIN   (0x7)
+#define HW_XGAIN_MASK     ((0x03 << 20|0x1<<15|0x1<<16 |0x1<<9|0x1<<10)|HW_ENABLE_XGAIN)
+#define HW_ENABLE_XGAIM_0 (0x1)
+#define HW_ENABLE_XGAIM_1 (0x1<<1)
+#define HW_ENABLE_XGAIM_2 (0x1<<2)	
+
+#define SW_XGAIN_MASK     (0x7|0x03 << 20|0x1<<15|0x1<<16 |0x1<<9|0x1<<10 |0x3<<6)
+#define SW_ENABLE_XGAIM_0 (0x1<<19|0x1<<20)
+#define SW_ENABLE_XGAIM_1 (0x1<<19|0x2<<20)
+#define SW_ENABLE_XGAIM_2 (0x1<<19|0x3<<20)
+
+#define XGAIN0_INT_ENABLE  (0x1<<15|0x1<<16|0x1<<9|0x1<<10)
+
+#define ADC_POWERDOWN_EN  (0x0 << 8) 
+#define ADC_POWERDOWN_DIS  (0x1 << 8) 
+
+#define CVBS_PLUG_REPEAT_TIME      2
+
+#define HW_EOC_DROP_COUNTER (0x2<<3) //BIT3~5 always set 2
+
+#define SW_EOC_DROP_COUNTER (0x1<<3) //BIT3~5 always set 1
+
+#define GAINO_INT_DEFAULT_MAX_TH      0x15 //21
+
+struct timer_list xain_change_timer;                                                                                                                                                                          
+/* *INDENT-OFF* */                                                                                                                                                        
+static pmuReg_t pmu_reg[] = {                                                                                                                                             
+/*  {reg_off,   bits_mask,     lock_bits,    init_val,    init_mask } */                                                                                                  
+    {PLL_CLK,   PLL_CLK_BIT,   PLL_CLK_BIT,      0x0,      PLL_CLK_BIT }, // ADC clock selection                                                                          
+    {GATE_CLK,  GATE_CLK_BIT,  GATE_CLK_BIT, 	 0x0<<3,   0x1<< 3}, // Enable ADC 
+    {0x74,  CLOCK_DIVID_BIT,  CLOCK_DIVID_BIT, 	 (0x27 << 16), CLOCK_DIVID_BIT },//30MHZ /40 = 750khz
+};                                                                                                                                                                        
+                                                                                                                                                                          
+static pmuRegInfo_t pmu_reg_info = {                                                                                                                                      
+    DEV_NAME,                                                                                                                                                             
+    ARRAY_SIZE(pmu_reg),                                                                                                                                                  
+    ATTR_TYPE_NONE,                                                                                                                                                       
+    pmu_reg,                                                                                                                                                              
+};                                                                                                                                                                        
+
+static struct task_struct *saradc_thread = NULL;
+static volatile int saradc_thread_runing = 0;
+struct semaphore    polling_sem; /*spec for 8139 usage*/
+
+static volatile unsigned int g_tv100_base = 0;
+static volatile unsigned int g_adda_base = 0;
+
+static int  polling_process_is_init = 0;
+static int  g_saradc_cvbs_info = ADDA_PLUG_OUT;/*0 :init ,1 : plug in ,2:plug out*/
+static int  g_saradc_debug = 0;/*1 : xgain1 ,2:xgain2 */
+static int  g_saradc_forcecvbs = ADDA_PLUG_AUTO;/*0 :init ,1 : plug in ,2:plug out*/
+static unsigned int  g_cvbs_on_tsr = HW_OUTPUT_VOL_THR_ON;
+static unsigned int  g_cvbs_off_tsr = HW_OUTPUT_VOL_THR_OFF;
+static u32 g_polling_time = POLLING_DELAY;
+
+static u32 g_gain_mask = 0;
+static u32 g_xgain0_en = 0;
+static u32 g_xgain1_en = 0;
+static u32 g_xgain2_en = 0;
+static u32 g_eoc_drop  = 0;
+static u32 g_base_set  = 0;
+static u32 g_base_gain2_set  = 0x09000100;
+
+extern  u32    g_recovery_cnt;
+extern  unsigned int poll_mode;
+extern  unsigned short auto_interval[3];
+/************************************/
+void Platform_Set_ADDA_TVBS(int enable);
+
+/**********************************/
+int register_scu(void)                                                                                                                                                    
+{                                                                                                                                                                         
+    scu_fd = ftpmu010_register_reg(&pmu_reg_info);                                                                                                                        
+    if (scu_fd < 0) {                                                                                                                                                     
+        printk("Failed to register %s scu\n", DEV_NAME);                                                                                                                  
+        return -1;                                                                                                                                                        
+    }                                                                                                                                                                     
+    return 0;                                                                                                                                                             
+}                                                                                                                                                                         
+                                                                                                                                                                          
+                                                                                                                                                                          
+int deregister_scu(void)                                                                                                                                                  
+{                                                                                                               
+    int ret = 0;                                                                                                                                                   
+                                                                                                                                    
+                                                                                                                                                                          
+    if (unlikely((ret = ftpmu010_write_reg(scu_fd, GATE_CLK ,0x1 << 3, GATE_CLK_BIT))!= 0))
+	{
+	    PRINT_E("saradc %s set as 0x%08X fail\n", __func__, GATE_CLK);                                                                                                        
+    }   
+	
+    if (scu_fd >= 0) {                                                                                                                                                    
+        if (ftpmu010_deregister_reg(scu_fd)) {                                                                                                                            
+            printk("Failed to deregister %s scu\n", DEV_NAME);                                                                                                            
+            scu_fd = -1;                                                                                                                                                  
+            return -1;                                                                                                                                                    
+        }                                                                                                                                                                 
+    }                                                                                                                                                                     
+    return 0;                                                                                                                                                             
+}                                                                                                                                                                         
+                                                                                                                                                                          
+int scu_probe(struct scu_t *p_scu)                                                                                                                                        
+{                                                                                                                                                                         
+    if (unlikely(register_scu() < 0))                                                                                                                                     
+    {                                                                                                                                                                     
+        printk("register_scu errr\n");                                                                                                                                    
+        return -1;                                                                                                                                                        
+    }
+
+    g_adda_base = (unsigned int) ioremap_nocache ((uint32_t)ADDA_PA_START,(ADDA_PA_END -  ADDA_PA_START +1));
+    g_tv100_base = (unsigned int)ioremap_nocache(TVE_FTTVE100_PA_BASE, TVE_FTTVE100_PA_SIZE);
+    printk(" * ADDA paddr=%x vaddr=%x tve paddr=%x vaddr=%x\n",ADDA_PA_START,g_adda_base,TVE_FTTVE100_PA_BASE,g_tv100_base);
+    return 0;                                                                                                                                                             
+}                                                                                                                                                                         
+                                                                                                                                                                          
+int scu_remove(struct scu_t *p_scu)                                                                                                                                       
+{                                                                                                                                                                         
+    int ret;                                                                                                                                                              
+                                                                                                                                                                          
+    ret = deregister_scu();  
+
+     __iounmap((void *)g_adda_base);
+    g_adda_base = 0;
+    __iounmap((void *)g_tv100_base);
+    g_tv100_base = 0;
+    
+    return ret;                                                                                                                                                           
+}                                                                                                                                                                         
+                                                                                                                                                                          
+int set_pinmux(void)                                                                                                                                                      
+{                                                                                                                                                                         
+    unsigned int pmu_mfps = ftpmu010_read_reg(PLL_CLK);                                                                                                               
+    int ret = 0;                                                                                                                                                      
+                                                                                                                                                                          
+    pmu_mfps &= ~(PLL_CLK_BIT);                                                                                                                                       
+                                                                                                                                                                          
+    if (unlikely((ret = ftpmu010_write_reg(scu_fd, PLL_CLK , 0, PLL_CLK_BIT))!= 0))
+    {
+	    PRINT_E("%s set as 0x%08X\n", __func__, pmu_mfps);                                                                                                        
+    }                                                                                                                                                                 
+    pmu_mfps = ftpmu010_read_reg(PLL_CLK);                                                                                                                            
+    PRINT_I(" * %s set as 0x%02X 0x%08X OK\n", __func__, PLL_CLK, pmu_mfps);
+    return ret;                                                                                                                                                           
+}
+#if 1
+static void _platform_process_xgain0_value(struct dev_data* p_dev_data)
+{
+    unsigned int vbase = (unsigned int)p_dev_data->io_vadr;
+    struct dev_specific_data_t* p_data  = (struct dev_specific_data_t*)&p_dev_data->dev_specific_data;
+    unsigned int adc_val;
+    int          len;
+    sar_adc_pub_data new_data;
+    
+    adc_val=SAR_ADC_RAW_REG_RD(vbase,FTSAR_ADC_DAT0);
+    if(g_saradc_debug)
+        printk("xgain0_value = %d\n",adc_val);
+    
+    if(adc_val == 0)
+        return;
+
+    new_data.adc_val = adc_val;
+    new_data.status  = KEY_XAIN_0;
+
+    Platform_Lock_Polling_Mutex();
+    
+    len = kfifo_in(
+		&p_data->fifo, 
+		&new_data,
+		sizeof(sar_adc_pub_data)
+		);
+    
+    Platform_UnLock_Polling_Mutex();
+
+	wake_up(&p_data->wait_queue);
+	
+     if(len < sizeof(sar_adc_pub_data)){
+		if(g_saradc_debug)
+        	printk("put data into fifo queue fail (GAIN0)\n");
+    }
+     
+}
+#endif
+static void _platform_process_xgain1_value(struct dev_data* p_dev_data)
+{
+    unsigned int vbase = (unsigned int)p_dev_data->io_vadr;
+    struct dev_specific_data_t* p_data  = (struct dev_specific_data_t*)&p_dev_data->dev_specific_data;
+    unsigned int adc_val;
+    int          len;
+    sar_adc_pub_data new_data;
+    
+    adc_val=SAR_ADC_RAW_REG_RD(vbase,FTSAR_ADC_DAT1);
+    if(g_saradc_debug)
+        printk("xgain1_value = %d\n",adc_val);
+    
+    if(adc_val == 0)
+        return;
+
+    new_data.adc_val = adc_val;
+    new_data.status  = KEY_XAIN_1;
+
+    Platform_Lock_Polling_Mutex();
+    
+    len = kfifo_in(
+		&p_data->fifo, 
+		&new_data,
+		sizeof(sar_adc_pub_data)
+		);
+    
+    Platform_UnLock_Polling_Mutex();
+
+	wake_up(&p_data->wait_queue);
+	
+    if(len < sizeof(sar_adc_pub_data)){
+        if(g_saradc_debug)
+            printk("put data into fifo queue fail \n");
+    }
+     
+}
+static int sar_adc_reset(struct dev_data *p_dev_data)
+{
+	/**/                                                                                                                                 
+    u32         base_addr = 0 ; 	
+	int   val = 0;
+	/*power down*/
+	base_addr = (u32)p_dev_data->io_vadr;
+
+	val = SAR_ADC_RAW_REG_RD(base_addr, FTSAR_ADC_CR0);
+
+	val &= ~(ADC_POWERDOWN_DIS);
+	val &= ~(HW_ENABLE_XGAIM_0|HW_ENABLE_XGAIM_1|HW_ENABLE_XGAIM_2);
+	
+	SAR_ADC_RAW_REG_WR(base_addr, FTSAR_ADC_CR0, val); 	
+    msleep(100);
+	/*enable hw chanel 0*/
+	val |= (ADC_POWERDOWN_DIS);
+	val |= HW_ENABLE_XGAIM_0;
+	
+	SAR_ADC_RAW_REG_WR(base_addr, FTSAR_ADC_CR0, val); 
+	msleep(100);
+	/*enable hw chanel 1*/
+	val &= ~(HW_ENABLE_XGAIM_0|HW_ENABLE_XGAIM_1|HW_ENABLE_XGAIM_2);
+	val |= HW_ENABLE_XGAIM_1;
+	
+	SAR_ADC_RAW_REG_WR(base_addr, FTSAR_ADC_CR0, val); 
+	msleep(10);
+	/*enable hw chanel 2*/
+	val &= ~(HW_ENABLE_XGAIM_0|HW_ENABLE_XGAIM_1|HW_ENABLE_XGAIM_2);
+	val |= HW_ENABLE_XGAIM_2;
+	
+	SAR_ADC_RAW_REG_WR(base_addr, FTSAR_ADC_CR0, val); 
+	msleep(100);
+
+	/*enable all*/
+	val &= ~(HW_ENABLE_XGAIM_0|HW_ENABLE_XGAIM_1|HW_ENABLE_XGAIM_2);
+	val |= (p_dev_data->running_mode&0x7);
+	
+	SAR_ADC_RAW_REG_WR(base_addr, FTSAR_ADC_CR0, val); 
+	msleep(100);
+	
+	g_recovery_cnt++;
+    //printk("saradr reset v2.6!!!\n");
+	
+	return 0;
+}
+
+static void change_detect_xain(struct dev_data* data)                                                                                                                        
+{                                                                                                                                                                         
+    struct dev_data *p_dev_data = (struct dev_data*)data;                                                                                                             
+    unsigned int base = (unsigned int)p_dev_data->io_vadr;                                                                                                            
+	                                                                                                                                                                  
+    static int xain_num=0;                                                                                                                                                
+    unsigned int val,ran_flag = 0;
+    
+    val = SAR_ADC_RAW_REG_RD( base, FTSAR_ADC_CR0);
+    
+    do{
+        switch(xain_num){
+            case 0:
+				if(poll_mode){
+					if(p_dev_data->running_mode & SAR_ADC_RUNING_MODE_GAIN0){
+	                    //val &= ~g_gain_mask; 
+						if(p_dev_data->dev_specific_data.xgain0_int){
+							val = (g_xgain0_en|g_base_set |g_eoc_drop);
+							
+							SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_CR0, val);	
+						}
+						else{
+	                    	val = (g_xgain0_en|g_eoc_drop|g_base_set); 
+	                    	
+		                    SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_CR0, val);		
+							mdelay(1);
+							_platform_process_xgain0_value(p_dev_data);
+						}
+	                    xain_num = 1;
+	                    ran_flag = 1;                   
+	                }
+	                else{
+	                    xain_num = 1;
+	                    ran_flag = 0;         
+	                }
+				}else{
+	                if(p_dev_data->running_mode & SAR_ADC_RUNING_MODE_GAIN0){
+	                    //val &= ~g_gain_mask; 
+						if(p_dev_data->dev_specific_data.xgain0_int){
+							//val = (g_xgain0_en|g_base_set |g_eoc_drop);
+							//val = (g_base_set |g_eoc_drop);
+							//SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_CR0, val);	
+						}
+						else{
+	                    	//val = (g_xgain0_en|g_eoc_drop|g_base_set); 
+	                    	//val = (g_eoc_drop|g_base_set); 
+		                    //SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_CR0, val);		
+							mdelay(1);
+							_platform_process_xgain0_value(p_dev_data);
+						}
+	                    xain_num = 1;
+	                    ran_flag = 1;                   
+	                }
+	                else{
+	                    xain_num = 1;
+	                    ran_flag = 0;         
+	                }
+				}
+                break;
+            case 1:
+				if(poll_mode){
+					if(p_dev_data->running_mode & SAR_ADC_RUNING_MODE_GAIN1){
+	                    //val &= ~g_gain_mask; 
+	                    val = (g_xgain1_en|g_eoc_drop|g_base_set);
+	                    //val = (g_eoc_drop|g_base_set);
+	                    SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_CR0, val);
+	                    mdelay(1);
+	                    _platform_process_xgain1_value(p_dev_data);
+	                    xain_num = 2;
+	                    ran_flag = 1;                  
+	                }
+	                else{
+	                    xain_num = 2;
+	                    ran_flag = 0;                  
+	                }
+				}else{
+	                if(p_dev_data->running_mode & SAR_ADC_RUNING_MODE_GAIN1){
+	                    //val &= ~g_gain_mask; 
+	                    //val = (g_xgain1_en|g_eoc_drop|g_base_set);
+	                    //val = (g_eoc_drop|g_base_set);
+	                    //SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_CR0, val);
+	                    mdelay(1);
+	                    _platform_process_xgain1_value(p_dev_data);
+	                    xain_num = 2;
+	                    ran_flag = 1;                  
+	                }
+	                else{
+	                    xain_num = 2;
+	                    ran_flag = 0;                  
+	                }
+				}
+                break;
+            case 2:
+#if 1			
+				/*SW mode don't care cvbs*/
+				if(poll_mode){
+					xain_num = 0;
+                    ran_flag = 0;  
+				}else{
+	                if(p_dev_data->running_mode & SAR_ADC_RUNING_MODE_GAIN2){
+	                    //val &= ~g_gain_mask; 
+	                    //val = (g_xgain2_en|g_eoc_drop|g_base_gain2_set);  
+	                    //val = (g_eoc_drop|g_base_gain2_set);  
+	                    //SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_CR0, val);
+	                    mdelay(1);
+	                    Platform_Process_Volt_Threshold(p_dev_data);
+	                    xain_num = 0;
+	                    ran_flag = 1;                   
+	                }
+	                else{
+	                    xain_num = 0;
+	                    ran_flag = 0;                    
+	                }
+				}
+#endif				
+                break;
+            default:
+                printk("%s unexpected case\n",__func__);
+                break;
+        }
+    }while(!ran_flag);
+                                                                                                                        
+} 
+
+static int saradc_polling_thread(void *private)
+{
+    struct dev_data *p_dev_data = (struct dev_data*)private;
+    saradc_thread_runing = 1;
+
+    /*First time set adda and tvbs down*/
+    Platform_Set_ADDA_TVBS(0);
+    
+    do {
+        
+        change_detect_xain(p_dev_data);
+        msleep(g_polling_time);
+        
+    }while(!kthread_should_stop());
+    
+    saradc_thread_runing = 0;
+    return 0;
+}
+
+void Platform_Set_Init_Reg(struct dev_data *p_dev_data)                                                                                                                   
+{ 
+    unsigned int val;                                                                                                                                                 
+    unsigned int base = (unsigned int)p_dev_data->io_vadr;
+#if 1
+
+    unsigned char lmin=0,lmax=0;
+ 	
+    lmin = p_dev_data->dev_specific_data.xgain0_min & 0xff;
+	lmax = p_dev_data->dev_specific_data.xgain0_max & 0xff; 
+	
+	if(lmax == 0)
+		lmax = GAINO_INT_DEFAULT_MAX_TH;
+    
+    val = (lmax << 16)| lmin;/* set high threshold as 0x00010001 */                                                                                                                 
+    SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_THD0, val);
+
+#endif
+    val = SAR_ADC_RAW_REG_RD(g_adda_base, ADDA_DAC_REG);                                                                                                                
+    val |= 0x10;                                                                                                                                                      
+    SAR_ADC_RAW_REG_WR( g_adda_base, ADDA_DAC_REG, val); 
+	
+    //val= SAR_ADC_RAW_REG_RD(base, FTSAR_ADC_CR0);
+    //val = 0x0B018701;    
+    //val = 0x0B187F00|EOC_DROP_COUNTER; /*xgain 0 enable interrupt , xgain_1 xgain_2 polling mode*/
+    
+	if(!poll_mode){
+		g_gain_mask = HW_XGAIN_MASK;
+		g_xgain0_en = HW_ENABLE_XGAIM_0;
+		g_xgain1_en = HW_ENABLE_XGAIM_1;
+		g_xgain2_en = HW_ENABLE_XGAIM_2;
+		g_eoc_drop  = HW_EOC_DROP_COUNTER;
+		g_cvbs_on_tsr = HW_OUTPUT_VOL_THR_ON;
+        g_cvbs_off_tsr = HW_OUTPUT_VOL_THR_OFF;
+		g_saradc_forcecvbs = ADDA_PLUG_AUTO;
+	
+		if(p_dev_data->dev_specific_data.xgain0_int){
+			
+			val = 0x09018700|HW_EOC_DROP_COUNTER|(p_dev_data->running_mode&0x7);/*xgain 0 enable interrupt , xgain_1 xgain_2 polling mode*/			
+			g_base_set = val;
+		}	
+		else{
+			val = 0x09000100|HW_EOC_DROP_COUNTER|(p_dev_data->running_mode&0x7) ;
+			g_base_set = val; 
+		}
+
+		g_base_gain2_set = g_base_gain2_set | (p_dev_data->running_mode&0x7) ;
+		SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_AUTO_REQ0, auto_interval[0]);//50us
+		SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_AUTO_REQ1, auto_interval[1]);//100us
+		SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_AUTO_REQ2, auto_interval[2]);//frame base
+
+		
+	}
+	else{
+		g_gain_mask = SW_XGAIN_MASK;
+		g_xgain0_en = SW_ENABLE_XGAIM_0;
+		g_xgain1_en = SW_ENABLE_XGAIM_1;
+		g_xgain2_en = SW_ENABLE_XGAIM_2;
+		g_eoc_drop  = SW_EOC_DROP_COUNTER;
+		g_cvbs_on_tsr = SW_OUTPUT_VOL_THR_ON;
+        g_cvbs_off_tsr =SW_OUTPUT_VOL_THR_OFF;
+		g_saradc_forcecvbs = ADDA_PLUG_OUT;
+		if(p_dev_data->dev_specific_data.xgain0_int){
+			val = 0x09098700|SW_EOC_DROP_COUNTER;/*xgain 0 enable interrupt , xgain_1 xgain_2 polling mode*/
+			g_base_set = val;
+			g_base_gain2_set = val;
+		}
+		else{
+			val = 0x09080100|SW_EOC_DROP_COUNTER ; //0x0b480100
+			g_base_set = val;
+			g_base_gain2_set = val;
+		}
+		
+		SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_AUTO_REQ0, 0x0);//50ms
+		SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_AUTO_REQ1, 0x0);//100ms
+		SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_AUTO_REQ2, 0x0);//30ms
+			
+	}
+	SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_CR0, val); 	
+    udelay(50);
+
+	//sw polling set cvbs as zero
+	if(poll_mode)
+		Platform_Force_Set_ADDA_TVBS(0);	
+}
+                                                                                                                                                                          
+int Platform_Init_Pollign_Timer(struct dev_data *p_dev_data)                                                                                                             
+{    
+    init_MUTEX(&polling_sem);
+    
+    saradc_thread = kthread_create(saradc_polling_thread, (void*)p_dev_data, "saradc thread");
+    if (IS_ERR(saradc_thread)){
+        printk("SARADC: Error in creating kernel thread! \n");
+        return -1;
+    }
+
+    wake_up_process(saradc_thread); 
+    polling_process_is_init = 1;
+    return 0;
+}                                                                                                                                                                         
+                                                                                                                                                                          
+void Platform_Del_Pollign_Timer(void)                                                                                                                                     
+{
+    unsigned int val;
+    
+    if (saradc_thread)
+        kthread_stop(saradc_thread);
+    
+    while (saradc_thread_runing == 1)
+        msleep(1);
+    
+    /* turn on ADDA wrapper
+     */
+    /* 1. video_dac_stby low */
+    val = SAR_ADC_RAW_REG_RD(g_adda_base, ADDA_DAC_REG);                                                                                                                
+    val &= ~(0x1 << 3);
+    /* 2. PD, PSW_PD, ISO_ENABLE */
+    val &= ~(0x7); 
+    SAR_ADC_RAW_REG_WR(g_adda_base, ADDA_DAC_REG, val); 
+
+    /* turn on TVE100
+     */
+    val = SAR_ADC_RAW_REG_RD(g_tv100_base, TVE_POWER_DOWN_REG);
+    val &= ~(0x7);
+    SAR_ADC_RAW_REG_WR(g_tv100_base,TVE_POWER_DOWN_REG,val);   
+}                                                                                                                                                                         
+                                                                                                                                                                          
+void Platform_Process_Volt_Threshold(struct dev_data *p_dev_data)                                                                                    
+{
+    unsigned int vbase = (unsigned int)p_dev_data->io_vadr; 
+    unsigned int adc_val ,val; 
+    static int  out_detect_count = 0  ,int_detect_count = 0;
+	static int  zero_val = 0;
+        
+    adc_val=SAR_ADC_RAW_REG_RD(vbase,FTSAR_ADC_DAT2);
+
+    if(g_saradc_debug)
+        printk("Platform_Process_Volt_Threshold=%d-%d-%d\n",adc_val,g_saradc_cvbs_info,g_saradc_forcecvbs);
+
+    if(adc_val == 0 ){
+		zero_val++;
+		if(zero_val == 15){
+			zero_val = 0;
+			sar_adc_reset(p_dev_data);
+		}
+        return;
+    }
+
+    if(g_saradc_forcecvbs != ADDA_PLUG_AUTO){
+        return;
+    }
+
+    if(g_saradc_cvbs_info == ADDA_PLUG_IN && adc_val > g_cvbs_on_tsr){                                                                                                                                
+        out_detect_count++;
+        if(out_detect_count  < CVBS_PLUG_REPEAT_TIME){
+         
+            return;
+        }
+        out_detect_count = 0;
+        int_detect_count = 0;
+        printk(KERN_DEBUG "plug-out=%x\n",adc_val);
+        g_saradc_cvbs_info = ADDA_PLUG_OUT;
+        //pre_adda_status = ADDA_PLUG_OUT;
+        /* turn off ADDA wrapper
+         */
+        /* 1. set ISO enable */
+        val = SAR_ADC_RAW_REG_RD(g_adda_base, ADDA_DAC_REG);                                                                                                                
+        val |= (0x1);
+        SAR_ADC_RAW_REG_WR( g_adda_base, ADDA_DAC_REG, val); 
+        /* 2. PD, PSW_PD */
+        val |= (0x6); 
+        SAR_ADC_RAW_REG_WR( g_adda_base, ADDA_DAC_REG, val);
+
+        /* turn off TVE100
+         */
+        val = SAR_ADC_RAW_REG_RD(g_tv100_base, TVE_POWER_DOWN_REG);
+        val |= (0x7);
+        SAR_ADC_RAW_REG_WR(g_tv100_base,TVE_POWER_DOWN_REG,val); 
+  
+    }
+    else if(g_saradc_cvbs_info == ADDA_PLUG_OUT && adc_val < g_cvbs_off_tsr){ 
+        int_detect_count++;
+        if(int_detect_count  < CVBS_PLUG_REPEAT_TIME){
+            return;
+        }
+        int_detect_count = 0;
+        out_detect_count = 0;
+        printk(KERN_DEBUG "plug-in=%x\n",adc_val);
+        //pre_adda_status = ADDA_PLUG_IN;
+        g_saradc_cvbs_info = ADDA_PLUG_IN;
+        /* turn on ADDA wrapper
+         */
+        /* 1. video_dac_stby low */
+        val = SAR_ADC_RAW_REG_RD(g_adda_base, ADDA_DAC_REG);                                                                                                                
+        val &= ~(0x1 << 3);
+        SAR_ADC_RAW_REG_WR( g_adda_base, ADDA_DAC_REG, val);
+        /* 2. PD, PSW_PD, ISO_ENABLE */
+        val &= ~(0x7); 
+        SAR_ADC_RAW_REG_WR( g_adda_base, ADDA_DAC_REG, val); 
+
+        /* turn on TVE100
+         */
+        val = SAR_ADC_RAW_REG_RD(g_tv100_base, TVE_POWER_DOWN_REG);
+        val &= ~(0x7);
+        SAR_ADC_RAW_REG_WR(g_tv100_base,TVE_POWER_DOWN_REG,val);  
+		
+    }
+    else if(g_saradc_cvbs_info == ADDA_PLUG_IN && adc_val <= g_cvbs_on_tsr){
+        int_detect_count = 0;
+        out_detect_count = 0;
+    }
+    else if(g_saradc_cvbs_info == ADDA_PLUG_OUT && adc_val >= g_cvbs_off_tsr){
+        int_detect_count = 0;
+        out_detect_count = 0;
+    }
+    else {
+        if(g_saradc_debug)
+            printk("Uknow state=%d-%d\n",adc_val,g_saradc_cvbs_info);
+    }
+
+} 
+int Platform_SAR_ADC_GetData(struct dev_data *p_dev_data , sar_adc_pub_data* new_data)
+{
+    unsigned int base = (unsigned int)p_dev_data->io_vadr;
+    unsigned int value;
+
+    value=SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT0);
+
+    if(g_saradc_debug)
+        printk("xgain0_value = %d\n",value);
+      
+    if(value > 0x0) {
+        new_data->adc_val = value;
+        new_data->status = KEY_XAIN_0;
+        return 0;
+    }
+#if 0 
+
+    value = SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT1);
+    if(value > 0x0) {
+        new_data->adc_val = value;
+        new_data->status = KEY_XAIN_1;
+        return 0;
+    }
+   
+    value=SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT2); 
+    if(value > 0x0) {
+        new_data->adc_val = value;
+        new_data->status = KEY_XAIN_2;
+        return 0;
+    }
+#endif    
+    new_data->adc_val = 0;
+    new_data->status = 0;
+    return -1;
+}
+
+int Platform_Set_Polling_Time(unsigned int time_val)
+{
+   
+    if(time_val == 0)
+        return -1;
+    
+    g_polling_time =  time_val;
+   
+    return 0;
+}
+
+u32 Platform_Get_Polling_Time(void)
+{
+    return g_polling_time;
+}
+
+
+int Platform_Set_CVBS_THR_Value(unsigned int on_vlaue,unsigned int off_value)
+{
+    if(on_vlaue >= OUTPUT_VOL_THR_TOP || on_vlaue <= OUTPUT_VOL_THR_DOWN
+       || off_value >= OUTPUT_VOL_THR_TOP || off_value <= OUTPUT_VOL_THR_DOWN)
+       return -1;
+    
+    g_cvbs_on_tsr =  on_vlaue;
+    g_cvbs_off_tsr = off_value;
+    return 0;
+}
+
+int Platform_Get_CVBS_THR_Value(unsigned int *on_vlaue,unsigned int *off_value)
+{
+    if(on_vlaue == NULL || off_value == NULL)
+        return -1;
+   
+    *on_vlaue = g_cvbs_on_tsr;
+    *off_value = g_cvbs_off_tsr;
+    
+    return 0;
+}
+
+void Platform_Set_ADDA_TVBS(int enable)
+{
+    unsigned int val = 0;
+    if(enable)
+    {
+        /* turn on ADDA wrapper
+         */
+        /* 1. video_dac_stby low */
+        val = SAR_ADC_RAW_REG_RD(g_adda_base, ADDA_DAC_REG);                                                                                                                
+        val &= ~(0x1 << 3);
+        SAR_ADC_RAW_REG_WR( g_adda_base, ADDA_DAC_REG, val);
+        /* 2. PD, PSW_PD, ISO_ENABLE */
+        val &= ~(0x7); 
+        SAR_ADC_RAW_REG_WR( g_adda_base, ADDA_DAC_REG, val); 
+
+        /* turn on TVE100
+         */
+        val = SAR_ADC_RAW_REG_RD(g_tv100_base, TVE_POWER_DOWN_REG);
+        val &= ~(0x7);
+        SAR_ADC_RAW_REG_WR(g_tv100_base,TVE_POWER_DOWN_REG,val);      
+    }else{
+        /* turn off ADDA wrapper
+         */
+        /* 1. set ISO enable */
+        val = SAR_ADC_RAW_REG_RD(g_adda_base, ADDA_DAC_REG);                                                                                                                
+        val |= (0x1);
+        SAR_ADC_RAW_REG_WR( g_adda_base, ADDA_DAC_REG, val); 
+        /* 2. PD, PSW_PD */
+        val |= (0x6); 
+        SAR_ADC_RAW_REG_WR( g_adda_base, ADDA_DAC_REG, val);
+
+        /* turn off TVE100
+         */
+        val = SAR_ADC_RAW_REG_RD(g_tv100_base, TVE_POWER_DOWN_REG);
+        val |= (0x7);
+        SAR_ADC_RAW_REG_WR(g_tv100_base,TVE_POWER_DOWN_REG,val); 
+    }
+}
+
+int Platform_Force_Set_ADDA_TVBS(int force)
+{
+    if(force == ADDA_PLUG_IN && g_saradc_forcecvbs != ADDA_PLUG_IN){
+        Platform_Set_ADDA_TVBS(1);
+        g_saradc_forcecvbs = ADDA_PLUG_IN;
+        g_saradc_cvbs_info = ADDA_PLUG_IN;
+    }
+    else if(force == ADDA_PLUG_OUT && g_saradc_forcecvbs != ADDA_PLUG_OUT){
+        Platform_Set_ADDA_TVBS(0);
+        g_saradc_forcecvbs = ADDA_PLUG_OUT;
+        g_saradc_cvbs_info = ADDA_PLUG_OUT;
+    }
+    else if(force == ADDA_PLUG_AUTO && g_saradc_forcecvbs != ADDA_PLUG_AUTO){
+        g_saradc_forcecvbs = ADDA_PLUG_AUTO;
+    }
+    return 0;
+}
+
+int Platform_Force_Get_ADDA_TVBS(void)
+{
+    return  g_saradc_forcecvbs;   
+}
+
+int Platform_Get_CVBS_Info(void)
+{
+    return g_saradc_cvbs_info;
+}
+
+int Platform_Get_SARADC_Debug(void)
+{
+    return g_saradc_debug;
+}
+
+void Platform_Set_SARADC_Debug(int value)
+{
+    g_saradc_debug = value;
+}
+
+int Platform_Get_Polling_Timer_State(void)
+{
+    if(polling_process_is_init)
+        return 1;
+    return 0;
+}
+
+void Platform_Lock_Polling_Mutex(void)
+{
+    down(&polling_sem);    
+}
+
+void Platform_UnLock_Polling_Mutex(void)
+{
+    up(&polling_sem);    
+}
+
+int Platform_Check_Support_XGain(int num)
+{
+    if(num >=0 && num <= 2)
+        return 0;
+    return -1;    
+}
+unsigned int Platform_Direct_Get_XGain_Value(unsigned int base , int num)
+{
+    unsigned int value = 0;
+    
+    if(num == 0){
+        value=SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT0);       
+    }
+
+    if(num == 1){
+        value=SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT1);
+    }
+
+    if(num == 2){
+        value=SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT2);
+       
+    }
+    return value;
+}
+

--- a/arch/arm/mach-GM/sar-adc-drv/gm8287.c
+++ b/arch/arm/mach-GM/sar-adc-drv/gm8287.c
@@ -1,0 +1,226 @@
+#include "platform.h"                                                                                                                                                     
+#include "sar_adc_drv.h"                                                                                                                                                  
+#include "sar_adc_dev.h"                                                                                                                                                  
+#include <mach/ftpmu010.h>                                               
+                                                                                                                                         
+#include <linux/delay.h>                                                                                                                                                  
+#include <linux/timer.h>
+
+#if (HZ==1000)                                                                                                                                                  
+#define POLLING_DELAY 200
+#elif (HZ==100)
+#define POLLING_DELAY 20
+#else
+#define POLLING_DELAY 200
+#endif
+
+struct timer_list xain_change_timer;                                                                                                                                                             
+                                                                                                                                                                          
+#define PRINT_E(args...) do { printk(args); }while(0)                                                                                                                     
+#define PRINT_I(args...) do { printk(args); }while(0)                                                                                                                     
+                                                                                                                                                                          
+#define PLL_CLK          0xB8   /* ADC0 clock */                                                                                                                          
+#define PLL_CLK_BIT     (0x1<<22)                                                                                                                                         
+                                                                                                                                                                          
+#define GATE_CLK	 0x70  /* ADC0 clk select and pvalue */                                                                                                   
+#define GATE_CLK_BIT	(0xff << 24)                                                                                                                           
+
+                                                                               
+                                                                               
+                                                                               
+static int scu_fd;                                                                                                                                                        
+                                                                                                                                                                          
+/* *INDENT-OFF* */                                                                                                                                                        
+static pmuReg_t pmu_reg[] = {                                                                                                                                             
+/*  {reg_off,   bits_mask,     lock_bits,    init_val,    init_mask } */                                                                                                  
+    {PLL_CLK,   PLL_CLK_BIT,   PLL_CLK_BIT,      0x0<<22,         0x1 << 22 }, // ADC PLL clock selection                                                                 
+    {GATE_CLK,  GATE_CLK_BIT,  GATE_CLK_BIT, 	 (0x0f<<24|0x2<<30),0xff<<24}, /* pvalue is 16(0x0f+1) 12M/16=768K , clk sel is 0x2 for dividing  by cntyp */             
+};                                                                                        
+                                                                                                                                                                          
+static pmuRegInfo_t pmu_reg_info = {                                                                                                                                      
+    DEV_NAME,                                                                                                                                                             
+    ARRAY_SIZE(pmu_reg),                                                                                                                                                  
+    ATTR_TYPE_NONE,                                                                                                                                                       
+    pmu_reg,                                                                                                                                                              
+};                                                                                                                                                                        
+/* *INDENT-ON* */                                                                                                                                                         
+                                                                                                                                                                          
+int register_scu(void)                                                                                                                                                    
+{                                                                                                                                                                         
+    scu_fd = ftpmu010_register_reg(&pmu_reg_info);                                                                                                                        
+    if (scu_fd < 0) {                                                                                                                                                     
+        printk("Failed to register %s scu\n", DEV_NAME);                                                                                                                  
+        return -1;                                                                                                                                                        
+    }                                                                                                                                                                     
+    return 0;                                                                                                                                                             
+}                                                                                                                                                                         
+                                                                                                                                                                          
+int deregister_scu(void)                                                                                                                                                  
+{                                                                                                                                                                         
+    if (scu_fd >= 0) {                                                                                                                                                    
+        if (ftpmu010_deregister_reg(scu_fd)) {                                                                                                                            
+            printk("Failed to deregister %s scu\n", DEV_NAME);                                                                                                            
+            scu_fd = -1;                                                                                                                                                  
+            return -1;                                                                                                                                                    
+        }                                                                                                                                                                 
+    }                                                                                                                                                                     
+    return 0;                                                                                                                                                             
+}                                                                                                                                                                         
+                                                                                                                                                                          
+int scu_probe(struct scu_t *p_scu)                                                                                                                                        
+{                                                                                                                                                                         
+    if (unlikely(register_scu() < 0))                                                                                                                                     
+    {                                                                                                                                                                     
+        printk("register_scu errr\n");                                                                                                                                    
+        return -1;                                                                                                                                                        
+    }                                                                                                                                                                     
+    return 0;                                                                                                                                                             
+}                                                                                                                                                                         
+                                                                                                                                                                          
+int scu_remove(struct scu_t *p_scu)                                                                                                                                       
+{                                                                                                                                                                         
+    int ret;                                                                                                                                                              
+                                                                                                                                                                          
+    ret = deregister_scu();                                                                                                                                               
+    return ret;                                                                                                                                                           
+}                                                                                                                                                                         
+                                                                                                                                                                          
+int set_pinmux(void)                                                                                                                                                      
+{                                                                                                                                                                         
+    unsigned int pmu_mfps = ftpmu010_read_reg(PLL_CLK);                                                                                                               
+    int ret = 0;                                                                                                                                                      
+                                                                                                                                                                          
+    pmu_mfps &= ~(PLL_CLK_BIT);                                                                                                                                       
+                                                                                                                                                                          
+    if (unlikely((ret = ftpmu010_write_reg(scu_fd, PLL_CLK , 0, PLL_CLK_BIT))!= 0))                                                                                   
+    {                                                                                                                                                                 
+	PRINT_E("%s set as 0x%08X\n", __func__, pmu_mfps);                                                                                                        
+    }                                                                                                                                                                 
+    pmu_mfps = ftpmu010_read_reg(PLL_CLK);                                                                                                                            
+    PRINT_I("%s set as 0x%02X 0x%08X OK\n", __func__, PLL_CLK, pmu_mfps);                                                                                             
+                                                                                                                                                                          
+    return ret;                                                                                                                                                           
+}                                                                                                                                                                         
+                                                                                                                                                                          
+static void change_detect_xain(unsigned long data)                                                                                                                        
+{                                                                                                                                                                         
+    struct dev_data *p_dev_data = (struct dev_data*)data;                                                                                                             
+    unsigned int base = (unsigned int)p_dev_data->io_vadr;                                                                                                            
+	                                                                                                                                                                  
+    static int xain_num=0;                                                                                                                                                
+    int val;                                                                                                                                                              
+                                                                                                                                                                          
+    if(!xain_num){                                                                                                                                                        
+        val = 0x000B2021;                                                                                                                                                 
+        SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_CR0, val);                                                                                                                    
+        xain_num = 1;                                                                                                                                                     
+    }else{                                                                                                                                                                
+        val = 0x000B2022;                                                                                                                                                 
+        SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_CR0, val);                                                                                                                    
+        xain_num = 0;                                                                                                                                                     
+    }                                                                                                                                                                     
+    xain_change_timer.expires = jiffies + POLLING_DELAY;                                                                                                                  
+    add_timer(&xain_change_timer);                                                                                                                           
+}                                                                                                                                                                         
+                                                                                                                                                                          
+void Platform_Set_Init_Reg(struct dev_data *p_dev_data)                                                                                                                   
+{                                                                                                                                                                         
+    unsigned int val;                                                                                                                                                 
+    unsigned int base = (unsigned int)p_dev_data->io_vadr;                                                                                                            
+	                                                                                                                                                                  
+    val = 0x00100000;/* set high threshold as 0x10 */                                                                                                                 
+    SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_THD0, val);                                                                                                                       
+    val = 0x000E0000;/* set high threshold as 0x0E */                                                                                                                     
+    SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_THD1, val);                                                                                                                       
+    val = 0x000B2021;                                                                                                                                                     
+    SAR_ADC_RAW_REG_WR( base, FTSAR_ADC_CR0, val);                                                                                                                        
+    udelay(50);                                                                                                                                                           
+}                                                                                                                                                                         
+                                                                                                                                                                          
+int Platform_Init_Pollign_Timer(struct dev_data *p_dev_data)                                                                                                             
+{                                                                                                                                                                         
+/* Because xian 0 and xain 1 can't be selected at the same time, so we need to polling it */                                                                              
+   init_timer(&xain_change_timer);                                                                                                                                        
+   xain_change_timer.function = change_detect_xain;                                                                                                                       
+   xain_change_timer.data = ((unsigned long) p_dev_data);                                                                                                                 
+   xain_change_timer.expires = jiffies + POLLING_DELAY;                                                                                                                   
+   add_timer(&xain_change_timer);
+   return 0;
+}                                                                                                                                                                         
+
+int Platform_Get_Polling_Timer_State(void)
+{
+    return 1;
+}
+
+void Platform_Del_Pollign_Timer(void)                                                                                                                                     
+{                                                                                                                                                                         
+    del_timer(&xain_change_timer);                                                                                                                                    
+}                                                                                                                                                                         
+                                                                                                                                                                          
+void Platform_Process_Volt_Threshold(struct dev_data *p_dev_data)                                                                                    
+{                                                                                                                                                                         
+    /*8287 do nothing*/
+
+}  
+int Platform_SAR_ADC_GetData(struct dev_data *p_dev_data , sar_adc_pub_data* new_data)
+{    
+    unsigned int base = (unsigned int)p_dev_data->io_vadr;
+    unsigned int value;
+    
+    value=SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT0);
+    if(value > 0x0) {
+        new_data->adc_val = value;
+        new_data->status = KEY_XAIN_0;
+        return 0;
+    }
+
+    value=SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT1);
+    if(value > 0x0) {
+        new_data->adc_val = value;
+        new_data->status = KEY_XAIN_1;
+        return 0;
+    }
+
+    new_data->adc_val = 0;
+    new_data->status = 0;
+    return -1;
+}
+void Platform_Lock_Polling_Mutex(void)
+{
+    /*8287 do nothing*/    
+}
+
+void Platform_UnLock_Polling_Mutex(void)
+{
+    /*8287 do nothing*/  
+}
+
+int Platform_Check_Support_XGain(int num)
+{
+    if(num >=0 && num <= 1)
+        return 0;
+    return -1;    
+}
+unsigned int Platform_Direct_Get_XGain_Value(unsigned int base , int num)
+{
+    unsigned int value = 0;
+    
+    if(num == 0){
+        value=SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT0);
+        
+    }
+
+    if(num == 1){
+        value=SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT1);
+
+    }
+    return value;
+}
+
+int Platform_Get_SARADC_Debug(void)
+{
+    return 0;
+}
+
+

--- a/arch/arm/mach-GM/sar-adc-drv/sar_adc_dev.c
+++ b/arch/arm/mach-GM/sar-adc-drv/sar_adc_dev.c
@@ -1,0 +1,28 @@
+#define __SAR_ADC_DEV_C__
+
+#include <linux/kernel.h>
+#include <asm/page.h>
+#include <asm/io.h>
+#include "sar_adc_dev.h"
+#include <linux/delay.h>
+#include "platform.h"
+
+unsigned long jiffies_diff(unsigned long a, unsigned long b)
+{
+    if(a>b)
+        return (a-b);
+    else
+        return (0xFFFFFFFF-b+a);     //the only case is overflow
+}
+
+void SAR_ADC_ClearInt(unsigned int base)
+{
+    SAR_ADC_RAW_REG_WR(base, FTSAR_ADC_INT, ADC_WRAP_CLEAR_INT);
+}
+
+unsigned int SAR_ADC_GetData(unsigned int base)
+{
+	//int ret=0;
+	//ADC_WRAP_GET_DATA(base,ret);
+	return 0;
+}

--- a/arch/arm/mach-GM/sar-adc-drv/sar_adc_drv.c
+++ b/arch/arm/mach-GM/sar-adc-drv/sar_adc_drv.c
@@ -1,0 +1,1205 @@
+/*
+ * Revision History
+ * VER1.1 2013/11/27 prevent CVBS jitter for read saradc REG 2 in gm8139.c
+ * VER1.2 2013/12/11 printk error message add module name sar_adc_drv.c
+ * VER1.3 2013/12/13 support runing mode for 8139(gm8139.c,sar_adc_drv.c,sar_adc_drv.h)
+ * VER1.4 2014/05/19 add low and high int limit for gain0
+ * VER1.5 2014/06/18 filter gain0 vlaue is zero case;
+ * VER1.6 2014/08/05 prevent interrupt happen in init state and add 8136 support
+ * VER1.7 2014/08/28 add proc and debug for 8136 and 8139
+ * VER1.8 2014/09/09 REMOVE open adda clock in 8139 and 8136
+ * VER1.9 2.0 15/04/01 change saradc state machine xgin0 as polling mode and
+ *                     set 0x00 saradc reg don't set 0~2 bit and set eoc drop =1 
+ * VER2.1 15/09/30 change saradc hw polling mode
+  * VER2.2 15/10/12 adjust hw auto interval , gain2 as 0x1(one frame to request)
+  * VER2.3 15/10/12 adjust hw auto interval , let sw to switch enable bit.
+  * VER2.4.1 16/07/15     
+    (1) get value to wakeup kfifo that info app get quickly.
+  * VER2.5/08/04     
+    (1) set sample clk as 0x09000000
+    (2) set run_mode default is channel 0
+    (3) When CVBS get 0 for 10 times , will do recovery.
+ */
+
+#include "platform.h"
+#include "sar_adc_drv.h"
+#include "sar_adc_dev.h"
+#include "sar_adc_api.h"
+#include <linux/delay.h>
+#include <asm-generic/gpio.h>
+#include <linux/proc_fs.h>
+
+#if (HZ==1000)
+#define DEFAULT_SCAN_DURATION       80
+#define DEFAULT_REPEAT_DURATION     300
+#elif (HZ==100)
+#define DEFAULT_SCAN_DURATION       8
+#define DEFAULT_REPEAT_DURATION     30
+#else
+#define DEFAULT_SCAN_DURATION       80
+#define DEFAULT_REPEAT_DURATION     300
+#endif
+
+#define DEFAULT_CLOCK_DIVIDER       120
+
+
+/* module parameter */
+static unsigned int clk_div = DEFAULT_CLOCK_DIVIDER;
+static int g_xgain_num = 0; 
+module_param(clk_div, uint, S_IRUGO|S_IWUSR);
+MODULE_PARM_DESC(clk_div, "clock divider (base freq. is 12MHz)");
+
+static unsigned int run_mode = 0;
+module_param(run_mode, uint, S_IRUGO|S_IWUSR);
+MODULE_PARM_DESC(run_mode, "SARADC run_mode");
+
+unsigned int poll_mode = 0;
+
+module_param(poll_mode, uint, S_IRUGO|S_IWUSR);
+MODULE_PARM_DESC(poll_mode, "polling mode 0:HW 1:SW");
+
+static unsigned short gain0_lim[2] = {[0 ... (2 - 1)] = 0};
+module_param_array(gain0_lim, ushort, NULL, S_IRUGO | S_IWUSR);
+MODULE_PARM_DESC(gain0_lim, "gain0 min and max interrupt value");
+
+ unsigned short auto_interval[3] = {0x32,0x64,0x1};
+	
+module_param_array(auto_interval, ushort, NULL, S_IRUGO | S_IWUSR);
+	
+MODULE_PARM_DESC(auto_interval, "auto request interval");
+static unsigned short gain0_int = 0;
+module_param(gain0_int, ushort, S_IRUGO|S_IWUSR);
+MODULE_PARM_DESC(gain0_int, "SARADC gain0 int mode,default is 0");
+
+/* function for register device */
+void device_release(struct device *dev);
+
+/* function for register driver */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,24))
+int driver_probe(struct platform_device * pdev);
+int __devexit driver_remove(struct platform_device *pdev);
+#else
+int driver_probe(struct device * dev);
+int driver_remove(struct device * dev);
+#endif
+
+#if defined(CONFIG_PLATFORM_GM8139) || defined(CONFIG_PLATFORM_GM8136)
+
+//int scu_remove(struct scu_t *p_scu);
+/* proc init.
+ */
+static struct proc_dir_entry *saradc_proc_root = NULL;
+static struct proc_dir_entry *saradc_cvbs_info = NULL;
+static struct proc_dir_entry *saradc_gain_dbg = NULL;
+static struct proc_dir_entry *saradc_force_cvbs = NULL;
+static struct proc_dir_entry *saradc_cvbs_trs = NULL;
+static struct proc_dir_entry *saradc_polling_tms = NULL;
+#endif
+
+u32	g_recovery_cnt;
+/* function for register file operation */
+static int file_open(struct inode *inode, struct file *filp);
+static int file_release(struct inode *inode, struct file *filp);
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(2,6,36))
+static int file_ioctl(struct inode *inode, struct file *filp, unsigned int cmd, unsigned long arg);
+#else
+static long file_ioctl(struct file *filp, unsigned int cmd, unsigned long arg);
+#endif
+static ssize_t file_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos);
+static unsigned int file_poll(struct file *filp, poll_table *wait);
+
+static struct resource _dev_resource[] = {
+	[0] = {
+		.start = DEV_PA_START,
+		.end = DEV_PA_END,
+		.flags = IORESOURCE_MEM,
+	},
+	[1] = {
+		.start = DEV_IRQ_START,
+		.end = DEV_IRQ_END,
+		.flags = IORESOURCE_IRQ,
+	},
+};
+
+static struct platform_device _device = {
+	.name = DEV_NAME,
+	.id = -1, /* "-1" to indicate there's only one. */
+	#ifdef HARDWARE_IS_ON
+	.num_resources = ARRAY_SIZE(_dev_resource),
+	.resource = _dev_resource,
+	#endif
+	.dev  = {
+		.release = device_release,
+	},
+};
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,24))
+/*
+ * platform_driver
+ */
+static struct platform_driver _driver = {
+    .probe = driver_probe,
+    .remove = driver_remove,
+    .driver = {
+           .owner = THIS_MODULE,
+           .name = DEV_NAME,
+           .bus = &platform_bus_type, /* verify on GM8210 */
+    },
+};
+#else
+/*
+ * device_driver
+ */
+static struct device_driver _driver = {
+    .owner = THIS_MODULE,
+    .name = DEV_NAME,
+    .bus = &platform_bus_type,      /* used to represent busses like PCI, USB, I2C, etc */
+    .probe = driver_probe,
+    .remove = driver_remove,
+};
+#endif
+
+static struct file_operations _fops = {
+	.owner 			= THIS_MODULE,
+    #if (LINUX_VERSION_CODE < KERNEL_VERSION(2,6,36))
+	.ioctl 			= file_ioctl,
+	#else
+    .unlocked_ioctl = file_ioctl,
+    #endif
+	.open 			= file_open,
+	.release 		= file_release,
+	.read			= file_read,
+    .poll           = file_poll,
+};
+
+
+void device_release(struct device *dev)
+{
+    PRINT_FUNC();
+    return;
+}
+
+
+int register_device(struct platform_device *p_device)
+{
+    int ret = 0;
+
+    if (unlikely((ret = platform_device_register(p_device)) < 0)) 
+    {
+        printk("%s fails: platform_device_register not OK\n", __FUNCTION__);
+    }
+    
+    return ret;    
+}
+
+void unregister_device(struct platform_device *p_device)
+{
+    
+    platform_device_unregister(p_device);
+}
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,24))
+int register_driver(struct platform_driver *p_driver)
+{
+    PRINT_FUNC();
+	return platform_driver_register(p_driver);
+}
+#else
+int register_driver(struct device_driver* p_driver)
+{
+	return driver_register(p_driver);
+}
+#endif
+
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,24))
+void unregister_driver(struct platform_driver *p_driver)
+{
+    platform_driver_unregister(p_driver);
+}
+#else
+void ft2dge_unregister_driver(struct device_driver *p_driver)
+{
+    driver_unregister(p_driver);	
+}
+#endif
+
+/*
+ * register_cdev
+ */ 
+int register_cdev(struct dev_data* p_dev_data)
+{
+    int ret = 0;
+
+    /* alloc chrdev */
+    ret = alloc_chrdev_region(&p_dev_data->dev_num, 0, DEV_COUNT, DEV_NAME);
+    if (unlikely(ret < 0)) {
+        printk(KERN_ERR "%s:alloc_chrdev_region failed\n", __func__);
+        goto err1;
+    }
+    
+    cdev_init(&p_dev_data->cdev, &_fops);
+    p_dev_data->cdev.owner = THIS_MODULE;
+
+    ret = cdev_add(&p_dev_data->cdev, p_dev_data->dev_num, DEV_COUNT);
+    if (unlikely(ret < 0)) {
+        PRINT_E(KERN_ERR "%s:cdev_add failed\n", __func__);
+        goto err2;
+    }
+
+    /* create class */
+    p_dev_data->class = class_create(THIS_MODULE, CLS_NAME);
+	if (IS_ERR(p_dev_data->class))
+	{
+        PRINT_E(KERN_ERR "%s:class_create failed\n", __func__);
+        goto err3;
+	}
+
+    
+    /* create a node in /dev */
+    #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,26))
+	p_dev_data->p_device = device_create(
+        p_dev_data->class,              /* struct class *class */
+        NULL,                           /* struct device *parent */
+        p_dev_data->cdev.dev,    /* dev_t devt */
+	    p_dev_data,                     /* void *drvdata, the same as platform_set_drvdata */
+	    DEV_NAME                 /* const char *fmt */
+	);
+    #else
+	class_device_create(
+	    p_dev_data->class, 
+	    p_dev_data->cdev.dev,
+	    NULL, DEV_NAME
+	);
+    #endif
+    
+    PRINT_FUNC();
+    return 0;
+    
+    err3:
+        cdev_del(&p_dev_data->cdev);
+    
+    err2:
+        unregister_chrdev_region(p_dev_data->dev_num, 1);
+        
+    err1:
+        return ret;
+}
+
+
+/*
+ * unregister_cdev
+ */ 
+void unregister_cdev(struct dev_data* p_dev_data)
+{
+    PRINT_FUNC();
+
+    #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,26))
+    device_destroy(p_dev_data->class, p_dev_data->cdev.dev);
+    #else
+    class_device_destroy(p_dev_data->class, p_dev_data->cdev.dev);
+    #endif
+    
+    class_destroy(p_dev_data->class);
+    
+    cdev_del(&p_dev_data->cdev);
+    
+    unregister_chrdev_region(p_dev_data->dev_num, 1);
+    
+}
+
+static void process_key_adc(struct work_struct *work)
+{
+    struct delayed_work *delay_work = container_of(work, struct delayed_work, work);
+    struct dev_specific_data_t* p_data  = container_of(delay_work, struct dev_specific_data_t, key_work);
+    struct dev_data* p_dev_data = container_of(p_data, struct dev_data, dev_specific_data);
+    sar_adc_pub_data new_data;
+    int len = 0;
+	unsigned int 		vbase;
+
+	vbase = (unsigned int)p_dev_data->io_vadr;
+
+   Platform_SAR_ADC_GetData(p_dev_data,&new_data);
+
+
+	if(new_data.adc_val == 0){        
+		return ;
+    }
+
+    Platform_Lock_Polling_Mutex();
+
+    len = kfifo_in(
+		&p_data->fifo, 
+		&new_data,
+		sizeof(sar_adc_pub_data)
+		);
+    
+    Platform_UnLock_Polling_Mutex();
+
+	 wake_up(&p_data->wait_queue);
+    if(len < sizeof(sar_adc_pub_data)){
+        if(Platform_Get_SARADC_Debug())
+            printk("SAR_ADC : put data into fifo queue fail \n");
+    }
+}
+
+
+static void* dev_data_alloc_specific(struct dev_data* p_dev_data)
+{
+	struct dev_specific_data_t* p_data = &p_dev_data->dev_specific_data;
+
+    spin_lock_init(&p_data->lock);
+
+    p_data->scan_duration = DEFAULT_SCAN_DURATION;
+	/* setting fifo */
+    p_data->queue_len = 16;
+    if (unlikely(kfifo_alloc(
+		&p_data->fifo, 
+		p_data->queue_len * sizeof(sar_adc_pub_data), 
+		GFP_KERNEL))
+	)
+	{
+		panic("SADARC : kfifo_alloc fail in %s\n", __func__);
+        goto err0;
+	}
+    kfifo_reset(&p_data->fifo);
+    init_waitqueue_head(&p_data->wait_queue);
+	
+	/* setting work and workqueue */
+    INIT_DELAYED_WORK(&p_data->key_work, process_key_adc);	
+    init_MUTEX(&p_data->oper_sem);
+	printk(" * dev_data_alloc_specific done\n");
+    return p_data;
+
+
+    err0:
+    return NULL;
+}
+
+static void* dev_data_alloc(void)
+{
+    struct dev_data* p_dev_data = NULL;
+        
+    /* alloc drvdata */
+    p_dev_data = kzalloc(sizeof(struct dev_data), GFP_KERNEL);
+
+    if (unlikely(p_dev_data == NULL))
+    {
+        PRINT_E("%s Failed to allocate p_dev_data\n", __FUNCTION__);        
+        goto err0;
+    }
+
+	if (unlikely(dev_data_alloc_specific(p_dev_data) == NULL))
+    {
+        PRINT_E("%s Failed to allocate p_dev_data\n", __FUNCTION__);        
+        goto err1;
+    }
+
+   	DRV_COUNT_RESET();
+	return p_dev_data;
+	
+	err1:
+	    kfree (p_dev_data);
+		p_dev_data = NULL;
+    err0:
+        return p_dev_data;
+}
+
+static int dev_data_free_specific(struct dev_data* p_dev_data)
+{
+    struct dev_specific_data_t* p_data = &p_dev_data->dev_specific_data;
+    kfifo_free(&p_data->fifo);
+    return 0;
+}
+
+
+static int dev_data_free(struct dev_data* p_dev_data)
+{      
+    dev_data_free_specific(p_dev_data);
+    /* free drvdata */
+    kfree(p_dev_data);
+    p_dev_data = NULL;
+    
+	return 0;
+}
+
+static irqreturn_t drv_interrupt(int irq, void *base)
+{
+	unsigned int 		vbase;
+    struct dev_data*	p_dev_data = (struct dev_data*)base;
+    struct dev_specific_data_t*	p_data = &p_dev_data->dev_specific_data;
+    sar_adc_pub_data new_data;
+    int delay = 5 ,repeat_duration = 0;
+
+    if(HZ == 1000)
+        delay = 5;
+    else if(HZ == 100)
+        delay = 1;
+    else
+        delay = 5;
+
+	vbase = (unsigned int)p_dev_data->io_vadr;
+
+    SAR_ADC_ClearInt(vbase);
+
+    repeat_duration = p_data->scan_duration;
+    
+    if(jiffies_diff(jiffies, p_data->last_scan_jiffies) < repeat_duration){
+    	new_data.status = KEY_REPEAT;
+        return IRQ_HANDLED;       
+    }
+    else
+        new_data.status = KEY_IN;
+
+    p_data->last_scan_jiffies = jiffies;
+    /*prevent saradc semaphore isn't ok*/
+	if(Platform_Get_Polling_Timer_State())
+        schedule_delayed_work(&p_data->key_work, delay);
+
+    return IRQ_HANDLED;
+}
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,19))
+irqreturn_t drv_isr(int irq, void *dev)
+#else
+irqreturn_t drv_isr(int irq, void *dev, struct pt_regs *dummy)
+#endif
+{
+
+	return 	drv_interrupt(irq, dev);
+}
+
+int init_hardware(struct dev_data *p_dev_data)
+{
+	unsigned int base = (unsigned int)p_dev_data->io_vadr;
+    int ret = -1;
+
+    //assing running mode 
+    run_mode = (run_mode&SAR_ADC_RUNING_MODE_ALL);
+
+    if(!run_mode)
+        p_dev_data->running_mode = SAR_ADC_RUNING_MODE_GAIN0;
+    else
+        p_dev_data->running_mode = run_mode;
+
+    p_dev_data->dev_specific_data.xgain0_min = gain0_lim[0];
+    p_dev_data->dev_specific_data.xgain0_max = gain0_lim[1];
+	p_dev_data->dev_specific_data.xgain0_int = gain0_int;
+    //setup hardware    
+    ret = scu_probe(&p_dev_data->scu);
+    if (unlikely(ret != 0)) 
+    {
+        PRINT_E("%s fails at scu_probe %d\n", __FUNCTION__, ret);
+        goto err0;
+    }
+	
+	set_pinmux();
+
+	Platform_Set_Init_Reg(p_dev_data);
+	ret = Platform_Init_Pollign_Timer(p_dev_data);
+    if (unlikely(ret != 0)) 
+    {
+        PRINT_E("%s fails at Platform_Init_Pollign_Timer %d\n", __FUNCTION__, ret);
+        goto err1;
+    }
+    
+    SAR_ADC_ClearInt(base);
+
+	return 0;
+    
+    err1:
+        scu_remove(&p_dev_data->scu);
+
+	err0:
+        
+    return ret;
+}
+
+void exit_hardware(struct dev_data *p_dev_data)
+{
+
+    PRINT_FUNC();
+	
+	/****************************************************/
+	/**** start to implement your exit_hardware here ****/
+	/****************************************************/
+	
+	/* free gpio */
+
+    /* remove pmu */
+    scu_remove(&p_dev_data->scu);
+}
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,24))
+int driver_probe(struct platform_device * pdev)
+#else
+int driver_probe(struct device * dev)
+#endif
+{
+    #if (LINUX_VERSION_CODE < KERNEL_VERSION(2,6,24))
+    struct platform_device* pdev = to_platform_device(dev); // for version under 2.6.24 
+    #endif
+    struct dev_data *p_dev_data = NULL;
+    #ifdef HARDWARE_IS_ON
+    struct resource *res = NULL;  
+    #endif
+    struct dev_specific_data_t *p_data = NULL;
+  
+    int ret = 0;
+    PRINT_FUNC();
+    
+    /* 1. alloc and init device driver_Data */
+    p_dev_data = dev_data_alloc();
+    if (unlikely(p_dev_data == NULL)) 
+    {
+        printk("%s fails: kzalloc not OK", __FUNCTION__);
+        goto err1;
+    }
+    p_data = &p_dev_data->dev_specific_data;
+	
+    /* 2. set device_drirver_data */
+    #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,24))
+    platform_set_drvdata(pdev, p_dev_data);
+    #else
+    dev_set_drvdata(dev, p_dev_data);
+    #endif
+
+    p_dev_data->id = pdev->id;    
+   
+    /* 3. request resource of base address */
+    #ifdef HARDWARE_IS_ON
+    res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+
+    if (unlikely((!res))) 
+    {
+        PRINT_E("%s fails: platform_get_resource not OK", __FUNCTION__);
+        goto err2;
+    }
+
+    p_dev_data->io_size = res->end - res->start + 1;
+    p_dev_data->io_padr = (void*)res->start;
+
+    if (unlikely(!request_mem_region(res->start, p_dev_data->io_size, pdev->name))) {
+        PRINT_E("%s fails: request_mem_region not OK", __FUNCTION__);
+        goto err2;
+    }
+
+    p_dev_data->io_vadr = (void*) ioremap((uint32_t)p_dev_data->io_padr, p_dev_data->io_size);
+
+    if (unlikely(p_dev_data->io_vadr == 0)) 
+    {
+        PRINT_E("%s fails: ioremap_nocache not OK", __FUNCTION__);
+        goto err3;
+    }
+
+    /* 4. request_irq */
+    p_dev_data->irq_no = platform_get_irq(pdev, 0);
+    if (unlikely(p_dev_data->irq_no < 0)) 
+    {
+        PRINT_E("%s fails: platform_get_irq not OK", __FUNCTION__);
+        goto err3;
+    }
+    ret = request_irq(
+        p_dev_data->irq_no, 
+        drv_isr, 
+        #if (LINUX_VERSION_CODE < KERNEL_VERSION(2,6,24))
+        SA_INTERRUPT, 
+        #else
+        0,
+        #endif
+        DEV_NAME, 
+        p_dev_data
+    ); 
+
+    if (unlikely(ret != 0)) 
+    {
+        PRINT_E("%s fails: request_irq not OK %d\n", __FUNCTION__, ret);
+        goto err3;
+    }
+     
+    /* 6. init hardware */
+	ret = init_hardware(p_dev_data);
+    if (unlikely(ret < 0)) 
+    {
+        PRINT_E("%s fails: init_hardware not OK\n", __FUNCTION__);
+        goto err4;
+    }
+    #endif
+    
+
+    /* 7. register cdev */
+    ret = register_cdev(p_dev_data);
+    if (unlikely(ret < 0)) 
+    {
+        PRINT_E("%s fails: sar_adc_register_cdev not OK\n", __FUNCTION__);
+        goto err5;
+    }
+
+
+    /* 8. print probe info */
+    printk("%s done, io_vadr 0x%08X, io_padr 0x%08X 0x%08X\n", 
+    __FUNCTION__, 
+    (unsigned int)p_dev_data->io_vadr, 
+    (unsigned int)p_dev_data->io_padr, 
+    (unsigned int)p_dev_data
+    );
+    /*print runmod and gain0 min and max value*/
+     printk("%s done,runmod:0x%x,0x%x,0x%x,0x%x,poll_mode=%x\n", 
+    __FUNCTION__, 
+    (unsigned int)run_mode,gain0_int,gain0_lim[0],gain0_lim[1],poll_mode);
+    return ret;
+    
+    err5:
+        scu_remove(&p_dev_data->scu);
+
+    #ifdef HARDWARE_IS_ON
+    err4:
+        free_irq(p_dev_data->irq_no, p_dev_data);
+        
+    err3:
+        release_mem_region((unsigned int)p_dev_data->io_padr, p_dev_data->io_size);
+
+    err2:
+        #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,24))
+        platform_set_drvdata(pdev, NULL);
+        #else
+        dev_set_drvdata(dev, NULL);
+        #endif
+    #endif
+        
+
+    err1:
+        return ret;
+}
+#if defined(CONFIG_PLATFORM_GM8139) || defined(CONFIG_PLATFORM_GM8136)
+static int proc_dump_cvbs_info(char *page, char **start, off_t off, int count
+                                , int *eof, void *data)
+{
+    int tmp_data;
+    int len = 0;
+    
+    tmp_data = Platform_Get_CVBS_Info();
+
+    if(tmp_data == 0)
+        len += sprintf(page + len, "cvbs status: NONE\n");
+    else if (tmp_data == 0x01)
+        len += sprintf(page + len, "cvbs status: Plug in\n");
+    else if(tmp_data == 0x02)
+        len += sprintf(page + len, "cvbs status: Plug out\n");
+    else
+        len += sprintf(page + len, "cvbs status: Unknow\n");
+        
+    return len;
+}
+
+static int proc_dump_xgain_dbg(char *page, char **start, off_t off, int count
+                                , int *eof, void *data)
+{
+   return sprintf(page, "xgain_dbg_flag =%d\n", Platform_Get_SARADC_Debug());
+}
+
+static int proc_set_xgain_dbg(struct file *file, const char *buffer,unsigned long count, void *data)
+{
+    int mode_set = 0;
+    sscanf(buffer, "%d", &mode_set);
+
+    if(mode_set !=0 && mode_set !=1){
+        printk("set xgain debug must be 1 or 0 (%d)\n",mode_set);
+        return count;
+    }
+
+    Platform_Set_SARADC_Debug(mode_set);
+    
+    return count;
+}
+
+static int proc_dump_force_cvbs(char *page, char **start, off_t off, int count
+                                , int *eof, void *data)
+{
+    int len = 0;
+
+    len += sprintf(page + len, "force_cvbs state =%d\n", Platform_Force_Get_ADDA_TVBS());
+    len += sprintf(page + len, "0:auto,1:plugin,2:plugout\n");
+
+    return len;
+}
+
+static int proc_set_force_cvbs(struct file *file, const char *buffer,unsigned long count, void *data)
+{
+    int mode_set = 0;
+    sscanf(buffer, "%d", &mode_set);
+
+    if(mode_set !=0 && mode_set !=1 && mode_set !=2){
+        printk("0:auto,1:plugin,2:plugout (%d)\n",mode_set);
+        return count;
+    }
+
+    Platform_Force_Set_ADDA_TVBS(mode_set);
+    
+    return count;
+}
+
+static int proc_dump_polling_tms(char *page, char **start, off_t off, int count
+                                , int *eof, void *data)
+{
+    int len = 0; 
+
+	 len += sprintf(page + len, "ver : %s\n",SARADC_VER); 
+    len += sprintf(page + len, "Polling time: %d ms\n",Platform_Get_Polling_Time());   
+
+	 len += sprintf(page + len, "Recovery cnt: %d \n",g_recovery_cnt); 
+	 
+    return len;
+}
+
+static int proc_set_polling_tms(struct file *file, const char *buffer,unsigned long count, void *data)
+{
+    
+    u32 time_val = 0;
+    
+    sscanf(buffer, "%d", &time_val);
+
+    if(time_val ==0){
+        printk("can't set polling time as zero\n");
+        return count;
+    } 
+
+    Platform_Set_Polling_Time(time_val);
+    return count;
+}
+
+static int proc_dump_cvbs_tsr(char *page, char **start, off_t off, int count
+                                , int *eof, void *data)
+{
+    int len = 0;
+    int on_v = 0 ,off_v = 0;
+    
+    Platform_Get_CVBS_THR_Value(&on_v,&off_v);
+
+    len += sprintf(page + len, "CVBS ON THR: %d\n",on_v);
+    len += sprintf(page + len, "CVBS OFF THR: %d\n",off_v);
+    len += sprintf(page + len, "CVBS MAX THR: %d\n",OUTPUT_VOL_THR_TOP);
+    len += sprintf(page + len, "CVBS MIN THR: %d\n",OUTPUT_VOL_THR_DOWN);
+    return len;
+}
+
+static int proc_set_cvbs_tsr(struct file *file, const char *buffer,unsigned long count, void *data)
+{
+    int len = count;
+    unsigned char value[20];
+    unsigned int on_val = 0,off_val = 0;
+
+    memset(value,0x0,20);
+    if(len >= 20-1 ){
+        printk("set cvbs threshold fail (len(%d))\n",len);
+        return count;
+    }
+            
+    if(copy_from_user(value, buffer, len)){
+        printk("set cvbs threshold fai(copy_from_user)\n");
+        return count;
+    }
+    value[len] = '\0';
+    sscanf(value, "%d %d\n",&on_val,&off_val);
+       
+    if(on_val <= OUTPUT_VOL_THR_DOWN || off_val <= OUTPUT_VOL_THR_DOWN 
+       || off_val  >= OUTPUT_VOL_THR_TOP || on_val >= OUTPUT_VOL_THR_TOP){
+        printk("set cvbs threshold fai(on(%d)off(%d))\n",on_val,off_val);
+        return count; 
+    }
+
+    if(Platform_Set_CVBS_THR_Value(on_val,off_val) < 0)
+        printk("Platform_Set_CVBS_THR_Value fail(on(%d)off(%d))\n",on_val,off_val);  
+    
+    return count;        
+
+}
+
+
+static int saradc_proc_init(void)
+{
+    struct proc_dir_entry *p;
+
+    p = create_proc_entry("saradc", S_IFDIR | S_IRUGO | S_IXUGO, NULL);
+
+	if (p == NULL) {
+        panic("Fail to create proc saradc root!\n");
+    }
+
+    saradc_proc_root = p;
+
+    /*
+     * debug message
+     */
+    saradc_cvbs_info = create_proc_entry("cvbs_info", S_IRUGO, saradc_proc_root);
+
+	if (saradc_cvbs_info == NULL)
+        panic("Fail to create saradc_cvbs_info!\n");
+    saradc_cvbs_info->read_proc = (read_proc_t *) proc_dump_cvbs_info;
+    saradc_cvbs_info->write_proc = NULL;   
+
+    saradc_gain_dbg = create_proc_entry("xgain_dbg", S_IRUGO, saradc_proc_root);
+    
+    if (saradc_gain_dbg == NULL)
+        panic("Fail to create saradc_gain_dbg!\n");
+    saradc_gain_dbg->read_proc = (read_proc_t *) proc_dump_xgain_dbg;    
+    saradc_gain_dbg->write_proc =(write_proc_t *)proc_set_xgain_dbg;
+
+    saradc_force_cvbs = create_proc_entry("force_cvbs", S_IRUGO, saradc_proc_root);
+    
+    if (saradc_force_cvbs == NULL)
+        panic("Fail to create saradc_force_cvbs!\n");
+    saradc_force_cvbs->read_proc = (read_proc_t *) proc_dump_force_cvbs;    
+    saradc_force_cvbs->write_proc =(write_proc_t *)proc_set_force_cvbs;
+
+    saradc_cvbs_trs = create_proc_entry("cvbs_thr", S_IRUGO, saradc_proc_root);
+    
+    if (saradc_cvbs_trs == NULL)
+        panic("Fail to create saradc_cvbs_trs!\n");
+    saradc_cvbs_trs->read_proc = (read_proc_t *) proc_dump_cvbs_tsr;    
+    saradc_cvbs_trs->write_proc =(write_proc_t *)proc_set_cvbs_tsr;
+
+    saradc_polling_tms = create_proc_entry("polling_time", S_IRUGO, saradc_proc_root);
+    if (saradc_polling_tms == NULL)
+        panic("Fail to create saradc_cvbs_trs!\n");
+    saradc_polling_tms->read_proc = (read_proc_t *) proc_dump_polling_tms;    
+    saradc_polling_tms->write_proc =(write_proc_t *)proc_set_polling_tms; 
+    return 0;
+}
+
+static void saradc_proc_release(void)
+{
+    if (saradc_cvbs_info != NULL)
+        remove_proc_entry(saradc_cvbs_info->name, saradc_proc_root);
+    
+    if (saradc_gain_dbg != NULL)
+        remove_proc_entry(saradc_gain_dbg->name, saradc_proc_root);
+
+    if (saradc_force_cvbs != NULL)
+		remove_proc_entry(saradc_force_cvbs->name, saradc_proc_root);
+
+    if (saradc_cvbs_trs != NULL)
+		remove_proc_entry(saradc_cvbs_trs->name, saradc_proc_root);
+
+    
+    if (saradc_polling_tms != NULL)
+            remove_proc_entry(saradc_polling_tms->name, saradc_proc_root);
+
+    if (saradc_proc_root != NULL)
+		remove_proc_entry(saradc_proc_root->name, NULL);
+    
+   
+}
+#endif
+
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,24))
+int __devexit driver_remove(struct platform_device *pdev)
+#else
+int driver_remove(struct device * dev)
+#endif
+{      
+	struct dev_data* p_dev_data = NULL;
+
+    PRINT_FUNC();
+	
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,24))
+	p_dev_data = (struct dev_data *)platform_get_drvdata(pdev);	
+	#else
+	p_dev_data = (struct dev_data *)dev_get_drvdata(dev);
+	#endif
+    PRINT_I(" * %s p_dev_data 0x%08X\n", __FUNCTION__, (unsigned int)p_dev_data);
+
+    /* unregister cdev */
+    unregister_cdev(p_dev_data);
+    
+    #ifdef HARDWARE_IS_ON
+    /* free irq */
+    free_irq(p_dev_data->irq_no, p_dev_data);  
+    
+    Platform_Del_Pollign_Timer();
+    /* remove pmu */
+	exit_hardware(p_dev_data);
+	
+    /* release resource */
+    iounmap((void __iomem *)p_dev_data->io_vadr); 
+    release_mem_region((u32)p_dev_data->io_padr, p_dev_data->io_size);
+    #endif
+    
+	/* free device memory, and set drv data as NULL	*/
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,24))
+	platform_set_drvdata(pdev, NULL);
+	#else
+	dev_set_drvdata(dev, NULL);
+	#endif
+    
+    /* free device driver_data */
+	dev_data_free(p_dev_data);
+
+    
+#if defined(CONFIG_PLATFORM_GM8139) || defined(CONFIG_PLATFORM_GM8136)
+    saradc_proc_release();
+#endif
+	return 0;
+}
+
+
+
+static int __init module_init_func(void)
+{
+    int ret = 0;  
+
+    printk("\nWelcome to use %s %s\n", DEV_NAME ,SARADC_VER);
+
+    PRINT_FUNC();   
+    
+	 g_recovery_cnt = 0;
+    
+    /* register platform device */
+    ret = register_device(&_device);
+    if (unlikely(ret < 0)) 
+    {
+        PRINT_E("%s fails: ft2dge_register_device not OK\n", __FUNCTION__);
+        goto err1;
+    }
+
+    /* register platform driver     
+     * probe will be done immediately after platform driver is registered 
+     */
+    ret = register_driver(&_driver);
+    if (unlikely(ret < 0)) 
+    {
+        PRINT_E("%s fails: register_driver not OK\n", __FUNCTION__);
+        goto err2;
+    }
+    
+#if defined(CONFIG_PLATFORM_GM8139) || defined(CONFIG_PLATFORM_GM8136)
+    saradc_proc_init();
+#endif
+
+   
+    return 0;
+
+        
+    err2:
+        unregister_device(&_device);		
+
+    err1:
+    return ret;
+
+}
+
+static void __exit module_exit_func(void)
+{
+
+    printk(" ************************************************\n");
+    printk(" * Thank you to use %s,%s,goodbye *\n", DEV_NAME,SARADC_VER );
+    printk(" ************************************************\n");
+
+    PRINT_FUNC();   
+    
+    
+    /* unregister platform driver */     
+    unregister_driver(&_driver);
+
+
+	/* register platform device */
+    unregister_device(&_device);
+}
+
+static unsigned int file_poll(struct file *filp, poll_table *wait)
+{
+    unsigned int mask = 0;
+    struct flp_data* p_flp_data = filp->private_data;
+    struct dev_data* p_dev_data = p_flp_data->p_dev_data;
+    struct dev_specific_data_t* p_data = &p_dev_data->dev_specific_data;
+    unsigned long       cpu_flags;
+
+    if(down_interruptible(&p_data->oper_sem))
+        return -ERESTARTSYS;
+    poll_wait(filp, &p_data->wait_queue, wait);
+    spin_lock_irqsave(&p_data->lock, cpu_flags);
+    if(kfifo_len(&p_data->fifo))
+        mask |= POLLIN | POLLRDNORM;
+    spin_unlock_irqrestore(&p_data->lock, cpu_flags);
+    up(&p_data->oper_sem);
+
+    return mask;
+
+}
+
+static int file_open(struct inode *inode, struct file *filp)
+{
+	int ret_of_sar_adc_driver_open = 0;
+	
+	struct flp_data* p_flp_data = NULL;	
+	struct dev_data* p_dev_data = NULL;
+	
+    /* set filp */
+    p_dev_data = container_of(inode->i_cdev, struct dev_data, cdev);
+    
+	p_flp_data = kzalloc(sizeof(struct flp_data), GFP_KERNEL);
+	p_flp_data->p_dev_data = p_dev_data;
+
+	
+    /* increase driver count */	
+	DRV_COUNT_INC(); 
+
+	/* assign to private_data */
+    filp->private_data = p_flp_data;	
+
+
+    //PRINT_I("\n");
+	if (unlikely(((unsigned int)p_dev_data != (unsigned int)inode->i_cdev)))
+	{
+    	PRINT_I("%s p_dev_data 0x%08X 0x%08X\n", __FUNCTION__, (unsigned int)p_dev_data, (unsigned int)inode->i_cdev);
+    	PRINT_I("%s p_flp_data 0x%08X\n", __FUNCTION__, (unsigned int)p_flp_data);
+		ret_of_sar_adc_driver_open = -1;
+	}
+
+
+    return ret_of_sar_adc_driver_open;
+}
+
+
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(2,6,36))
+static int file_ioctl(struct inode *inode, struct file *filp, unsigned int cmd, unsigned long arg)
+#else
+static long file_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
+#endif
+{
+    #if (LINUX_VERSION_CODE < KERNEL_VERSION(2,6,36))
+	int ret = 0;
+    #else
+    long ret = 0;
+    #endif
+
+	struct flp_data* p_flp_data = filp->private_data;	
+	struct dev_data* p_dev_data = p_flp_data->p_dev_data;
+	struct dev_specific_data_t* p_data = &p_dev_data->dev_specific_data;
+
+
+    down(&p_data->oper_sem);
+
+    switch(cmd)
+    {
+        case SAR_ADC_KEY_ADC_DIRECT_READ:
+        {
+            int adc_val=0;
+           
+            adc_val = Platform_Direct_Get_XGain_Value((unsigned int)p_dev_data->io_vadr,g_xgain_num);
+           
+            if(copy_to_user((void *)arg, (void *)&adc_val, sizeof(int)) != 0) {
+                ret = -EFAULT;
+            } else {
+                ret = 0;
+            }
+            break;
+        }
+        case SAR_ADC_KEY_SET_REPEAT_DURATION:
+        {    
+            int  ms;
+	        if (unlikely(copy_from_user((void *)&ms, (void *)arg, sizeof(int))))
+		    {
+			    ret = -EFAULT;
+			    break;
+	        }
+            
+            if(ms>0)
+                p_data->scan_duration = msecs_to_jiffies(ms);
+            else
+                ret = -EFAULT;
+            break;
+        }  
+        case SAR_ADC_KEY_SET_XGAIN_NUM:
+        {
+            int  num;
+	        if (unlikely(copy_from_user((void *)&num, (void *)arg, sizeof(int))))
+		    {
+			    ret = -EFAULT;
+			    break;
+	        }
+         
+            if(Platform_Check_Support_XGain(num) == 0)
+                g_xgain_num = num;                
+            else
+                ret = -EFAULT;
+            break;        
+        }
+        default:
+            printk("%s cmd(0x%x) no define!\n", __func__, cmd);
+            break;
+    }
+
+    up(&p_data->oper_sem);
+
+    return ret;
+}
+
+
+
+static ssize_t file_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
+{
+ 	unsigned long 		cpu_flags;
+    int         ret = 0;
+    sar_adc_pub_data data;
+	struct flp_data* p_flp_data = filp->private_data;	
+	struct dev_data* p_dev_data = p_flp_data->p_dev_data;
+	struct dev_specific_data_t* p_data = &p_dev_data->dev_specific_data;
+
+
+    if (down_interruptible(&p_data->oper_sem))
+        return -ERESTARTSYS;
+
+	spin_lock_irqsave(&p_data->lock, cpu_flags);
+    if (kfifo_len(&p_data->fifo)==0)
+    {
+    	ret = 0;
+        goto exit;
+    }
+    
+    if (unlikely(
+		kfifo_out(
+			&p_data->fifo, 
+			(unsigned char *)&data,
+			sizeof(sar_adc_pub_data)
+		) <= 0))
+	{
+    	ret = -ERESTARTSYS;
+        goto exit;
+	}
+
+    if (copy_to_user(buf, &data, sizeof(sar_adc_pub_data)))
+    {
+    	ret = -ERESTARTSYS;
+        goto exit;
+    }
+
+    ret = sizeof(u8);
+
+	exit:
+	spin_unlock_irqrestore(&p_data->lock, cpu_flags);
+    up(&p_data->oper_sem);
+
+    return ret;
+}
+
+static int file_release(struct inode *inode, struct file *filp)
+{
+	struct flp_data* p_flp_data = filp->private_data;	
+
+    /* remove this filp from the asynchronously notified filp's */
+
+    kfree(p_flp_data);
+
+    filp->private_data = NULL;
+    
+    return 0;
+}
+
+
+module_init(module_init_func);
+module_exit(module_exit_func);
+
+MODULE_AUTHOR("GM Technology Corp.");
+MODULE_DESCRIPTION("GM fasync test");
+MODULE_LICENSE("GPL");


### PR DESCRIPTION
Using sar adc as a module causes crash on trying to read /dev/sar_adc_drv, but when using it as a kernel code integrated this problem not occurs anymore.