### PR TITLE
Update infinity6b0.dtsi

### DIFF
--- a/arch/arm/boot/dts/infinity6b0.dtsi
+++ b/arch/arm/boot/dts/infinity6b0.dtsi
@@ -389,8 +389,8 @@
             interrupts = <GIC_SPI INT_IRQ_FUART IRQ_TYPE_LEVEL_HIGH>, <GIC_SPI INT_IRQ_URDMA IRQ_TYPE_LEVEL_HIGH>;
             clocks = <&CLK_fuart>;
             dma = <1>;
-            pad = <PAD_UART0_TX>;
-            //pad = <PAD_FUART_TX>;
+            //pad = <PAD_UART0_TX>;
+            pad = <PAD_FUART_TX>;
             //pad = <PAD_GPIO4>;
             status = "ok";
 #ifdef CONFIG_CAM_CLK


### PR DESCRIPTION
with pad = <PAD_UART0_TX>  impossible to pinmux FUART (ttyS2).  Any echo / cat     to /dev/ttyS2  and /dev/ttyS1  reset control register (0x1f203C0C) to 0x10  and 0x100. 

with pad = <PAD_FUART_TX>   ttyS2  muxed to FUART_TX  by echo > /dev/ttyS2 and  can be fully controled by  0x1f203C0C.  ttyS1 also controlled by 0x1f203C0C  
(0x20 for ttyS2  at 43/43 pins,  0x200 for ttyS1 at 45/46 pins,  0x0 - gpio modes,   SSC335) 


also this DT  workable at ssc335DE. 
Tested at  ANJ  MS-J10 pcb and  UNV-RT  8283swc-we-b