### PR TITLE
clk: hisilicon: fix hibvt_reset_init() missing of_xlate

### DIFF
--- a/drivers/clk/hisilicon/reset.c
+++ b/drivers/clk/hisilicon/reset.c
@@ -132,6 +132,7 @@ int __init hibvt_reset_init(struct device_node *np, int nr_rsts)
 	rstc->rcdev.ops = &hisi_reset_ops;
 	rstc->rcdev.of_node = np;
 	rstc->rcdev.of_reset_n_cells = 2;
+	rstc->rcdev.of_xlate = hisi_reset_of_xlate;
 	rstc->rcdev.nr_resets = nr_rsts;
 
 	rstc->membase = of_iomap(np, 0);


### PR DESCRIPTION
## Summary

- `hibvt_reset_init()` in `drivers/clk/hisilicon/reset.c` sets `of_reset_n_cells = 2` but omits setting `rcdev.of_xlate = hisi_reset_of_xlate`
- This causes `reset_controller_register()` to silently override `of_reset_n_cells` to 1 and use `of_reset_simple_xlate`, breaking all devices with `#reset-cells = <2>` (offset, bit format) such as hisi-femac ethernet
- The fix adds the missing `of_xlate` assignment, matching what the sibling `hisi_reset_init()` function already does correctly in the same file

## Details

When `reset_controller_register()` sees `!rcdev->of_xlate`, it forces `of_reset_n_cells = 1` and assigns `of_reset_simple_xlate`. This means:

1. DT nodes specifying two reset args (offset, bit) trigger a WARN because `args_count (2) != of_reset_n_cells (1)`
2. The simple xlate checks `args[0] >= nr_resets` where nr_resets is typically 256, but the raw offset value can easily exceed this, returning `-EINVAL`

## Test plan

- [ ] Boot OpenIPC firmware on hi3516ev300 QEMU machine and verify hisi-femac ethernet initializes without reset controller warnings
- [ ] Confirm `dmesg` shows no `WARN` from reset framework during boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)