### PR TITLE
arm: dts: hisilicon: hi3516dv300: fix UART clock, enable ethernet, drop SPI clamp

### DIFF
--- a/arch/arm/boot/dts/hisilicon/hi3516dv300-demb.dts
+++ b/arch/arm/boot/dts/hisilicon/hi3516dv300-demb.dts
@@ -26,13 +26,18 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <160000000>;
-		/* Limit to 16MB to avoid 4-byte address mode issues */
-		spi-tx-bus-width = <1>;
-		spi-rx-bus-width = <1>;
 	};
 };
 
-/* mdio0 disabled — see femac comment above */
+&mdio0 {
+	hisilicon,phy-reset-delays-us = <10000 20000 150000>;
+	phy0: ethernet-phy@1 {
+		reg = <1>;
+	};
+};
 
-/* femac disabled — built-in driver hangs in port_init.
- * Ethernet brought up by vendor OSAL load_hisilicon script. */
+&hisi_femac0 {
+	mac-address = [00 00 00 00 00 00];
+	phy-mode = "mii";
+	phy-handle = <&phy0>;
+};

--- a/arch/arm/boot/dts/hisilicon/hi3516dv300.dtsi
+++ b/arch/arm/boot/dts/hisilicon/hi3516dv300.dtsi
@@ -67,12 +67,6 @@
 		interrupt-parent = <&gic>;
 		ranges;
 
-		clk_apb: clk_apb {
-			compatible = "fixed-clock";
-			#clock-cells = <0>;
-			clock-frequency = <24000000>;
-		};
-
 		sysctrl: system-controller@12020000 {
 			compatible = "hisilicon,sysctrl";
 			reg = <0x12020000 0x1000>;
@@ -90,7 +84,7 @@
 				compatible = "arm,pl011", "arm,primecell";
 				reg = <0x120a0000 0x1000>;
 				interrupts = <0 6 4>;
-				clocks = <&clk_apb>;
+				clocks = <&clock HI3516DV300_UART0_CLK>;
 				clock-names = "apb_pclk";
 				status = "okay";
 			};
@@ -116,9 +110,6 @@
 			status = "disabled";
 		};
 
-		/* Ethernet — disabled in DTS to avoid built-in femac probe hang.
-		 * The vendor load_hisilicon script brings up ethernet via
-		 * devmem CRG init + OSAL modules at runtime. */
 		mdio0: mdio@10011100 {
 			compatible = "hisilicon,hisi-femac-mdio";
 			reg = <0x10011100 0x10>;
@@ -128,7 +119,6 @@
 			reset-names = "external-phy";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			status = "disabled";
 		};
 
 		hisi_femac0: ethernet@10010000 {
@@ -139,15 +129,12 @@
 			clocks = <&clock HI3516DV300_ETH0_CLK>;
 			resets = <&clock 0x16c 0>;
 			reset-names = "mac";
-			status = "disabled";
 		};
 
-		/* I2C — needed for sensor communication */
 		i2c_bus0: i2c@120b0000 {
 			compatible = "hisilicon,hibvt-i2c";
 			reg = <0x120b0000 0x1000>;
 			clocks = <&clock HI3516DV300_I2C0_CLK>;
-			status = "disabled";
 		};
 
 		/* Vendor media subsystem — initialized by OSAL modules */


### PR DESCRIPTION
## Summary

Two root-cause fixes for hi3516av300/hi3516dv300/hi3516cv500 boot on the
modern (7.0) kernel, replacing earlier workarounds. All verified on real
hardware (hi3516av300_imx415).

### 1. UART clock: use real CRG gate, not fake fixed-clock

The minimal DTSI used a fake \`fixed-clock\` named \`clk_apb\` for uart0's
\`apb_pclk\`. The pl011 driver claimed that no-op clock; nobody held a
reference on the actual CRG gate \`HI3516DV300_UART0_CLK\`. After init,
\`clk_disable_unused()\` disabled the gate → console UART lost its clock →
kernel hung silently right after \`clk: Disabling unused clocks\`.

Wire uart0 to the real CRG clock so the gate is properly refcounted. No
\`clk_ignore_unused\` cmdline workaround needed; boot reaches login.

### 2. Re-enable mdio0 / hisi_femac0 / i2c_bus0

These were marked \`status = "disabled"\` on the suspicion that femac
probe hung at \`port_init\` writing MAC_PORTSEL. Interactive register
probing on real HW (devmem to MAC_PORTSEL, GLB_SOFT_RESET, GLB_HOSTMAC)
showed registers respond fine — the apparent femac hang was just the
\`clk_disable_unused\` UART death from issue 1 above.

### 3. DEMB board: wire PHY for MDIO

Upstream \`mdio-hisi-femac\` requires \`hisilicon,phy-reset-delays-us\`
when an \`external-phy\` reset is declared (vendor 4.9 driver doesn't;
upstream 7.0 does). Without it, MDIO probe returned -EINVAL and femac
couldn't connect to the PHY. Add the standard 10/20/150 ms delays
(matching hi3516ev300-demb), an \`ethernet-phy@1\` child node, and wire
\`hisi_femac0\` via \`phy-handle\` / \`phy-mode = "mii"\`.

### 4. DEMB board: drop 16 MB SPI NOR clamp

Removed the \`spi-tx-bus-width = <1>\` / \`spi-rx-bus-width = <1>\` clamp
that was added under the assumption 4-byte addressing on MX25L256 hangs
hisi-sfc. Verified on real HW: \`md5sum /dev/mtd4\` (reads 19.43 MB past
the 16 MB boundary) completes in 1.57 s with no errors.

## Test plan

Tested on hi3516av300_imx415 board (CV500 platform):

- [x] Kernel boots to login console without \`clk_ignore_unused\`
- [x] eth0 UP @ 100 Mbps full duplex, MDIO probes Generic PHY (id 0x02430c54)
- [x] \`ping\` to gateway works (~1 ms RTT)
- [x] Full 32 MB SPI NOR readable (md5sum /dev/mtd4 in 1.57 s)
- [x] jffs2 + overlayfs persist on mtd4, /etc/fw_env.config sticks across reboots
- [x] Dual-core SMP active

Companion firmware-side changes (re-enabling \`CONFIG_HISI_FEMAC=y\`,
\`CONFIG_OVERLAY_FS=y\`, \`CONFIG_JFFS2_FS=y\`, \`CONFIG_PACKET=y\`) are in
openipc/firmware PR #2023 \`feat/hi3516av300-neo\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)