### PR TITLE
arm: dts: hisilicon: hi3516dv300: 1 GiB DDR + CMA-default reserved-memory

### DIFF
--- a/arch/arm/boot/dts/hisilicon/hi3516dv300-demb.dts
+++ b/arch/arm/boot/dts/hisilicon/hi3516dv300-demb.dts
@@ -13,7 +13,9 @@
 
 	memory {
 		device_type = "memory";
-		reg = <0x80000000 0x10000000>;
+		/* 1 GiB DDR — boards typically ship with 1 GiB; U-Boot
+		 * cmdline mem=${osmem} can clamp lower if needed. */
+		reg = <0x80000000 0x40000000>;
 	};
 };
 

--- a/arch/arm/boot/dts/hisilicon/hi3516dv300.dtsi
+++ b/arch/arm/boot/dts/hisilicon/hi3516dv300.dtsi
@@ -60,6 +60,27 @@
 		clock-frequency = <50000000>;
 	};
 
+	/* CMA as the base allocator: reusable + linux,cma-default makes
+	 * dma_alloc and HiSilicon MMZ pull from this pool, while letting
+	 * the kernel borrow the same pages for movable allocations when
+	 * they are not pinned for DMA. Sized for 4K capture pipelines
+	 * (IMX415 3840x2160 + multi-channel encoders).
+	 * See OpenIPC wiki en/memory-tuning.md.
+	 */
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		mmz_cma: mmz {
+			compatible = "shared-dma-pool";
+			size = <0x30000000>; /* 768 MiB */
+			alloc-ranges = <0x80000000 0x40000000>;
+			reusable;
+			linux,cma-default;
+		};
+	};
+
 	soc {
 		#address-cells = <1>;
 		#size-cells = <1>;


### PR DESCRIPTION
## Summary

Brings hi3516dv300 / hi3516av300 in line with the EV300 neo pattern and
the OpenIPC wiki's [\"CMA as base allocator\"](https://github.com/OpenIPC/wiki/blob/master/en/memory-tuning.md)
recommendation, so 4K capture pipelines actually fit in memory on real
hardware (1 GiB-DDR boards).

### Changes

1. **\`hi3516dv300-demb.dts\`**: bump \`memory.reg\` from 256 MiB to
   1 GiB. The board physically has 1 GiB (\`fw_printenv totalmem\` =
   \`1024M\`); U-Boot's \`mem=\${osmem}\` clamps lower if a particular
   variant has less.

2. **\`hi3516dv300.dtsi\`**: add a \`reserved-memory\` node \`mmz_cma\`
   with:
   \`\`\`
   compatible = \"shared-dma-pool\";
   size = <0x30000000>;            // 768 MiB
   alloc-ranges = <0x80000000 0x40000000>;
   reusable;
   linux,cma-default;
   \`\`\`

### Why this matters

Before, with the static \`CONFIG_CMA_SIZE_MBYTES=192\` carve-out the
firmware was using:

\`\`\`
Free MMZ mem after allocation: 5616KB
ERR_VB_NOMEM / ERR_VENC_NOMEM
\`\`\`

After (1 GiB visible + 768 MiB reusable CMA):

\`\`\`
MemTotal:   1031628 kB
CmaTotal:    786432 kB
Free MMZ mem after allocation: 617352KB
HiSilicon SDK started
RTSP server started on port 554
\`\`\`

\`reusable\` lets the kernel borrow CMA pages for movable allocations
when the vendor MMZ isn't pinning them, so OS-visible memory is the
full 1 GiB rather than a 256 MiB hole.

### Test plan (verified on hi3516av300_imx415)

- [x] Boots with \`mem=1024M\`, MemTotal = 1 GiB
- [x] CmaTotal = 768 MiB at 0x90000000
- [x] majestic 4K H264 + MJPEG channels both succeed (no NOMEM)
- [x] RTSP listening on :554
- [x] HTTP 4K snapshot works (3840x2160 baseline JPEG)

Companion firmware-side patches incoming:
- drop \`CONFIG_CMA_SIZE_MBYTES\` (let DT control)
- update \`load_hisilicon\` to skip the legacy \`os_mem >= total_mem\`
  validity check when CMA is active (it's only meaningful for the
  raw-mmz allocator path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)