### PR TITLE
hi_cma: synthesize fallback zone from default CMA when no mmz= passed

### DIFF
--- a/drivers/hisilicon/cma/hi_cma.c
+++ b/drivers/hisilicon/cma/hi_cma.c
@@ -134,7 +134,31 @@ struct cma_zone *hisi_get_cma_zone(const char *name)
 		}
 
 	if (i == num_zones) {
-		return NULL;
+		/*
+		 * No zone with this name was registered via the cmdline mmz=.
+		 * That's the case on stock OpenIPC firmware where the U-Boot
+		 * bootargs were never customised — historically the vendor
+		 * binary hi_osal.ko had its own raw allocator and didn't need
+		 * a hisi_zone, but openhisilicon's cma_allocator.c expects one.
+		 *
+		 * Synthesize a single fallback zone backed by the kernel's
+		 * default CMA pool (CONFIG_CMA_SIZE_MBYTES / cma=). This lets
+		 * existing installs work after a sysupgrade without any
+		 * U-Boot bootargs change.
+		 */
+		static struct cma_zone fallback_zone;
+		struct cma *def = dma_contiguous_default_area;
+
+		if (def == NULL || fallback_zone.nbytes != 0)
+			return fallback_zone.nbytes ? &fallback_zone : NULL;
+
+		fallback_zone.pdev.coherent_dma_mask = DMA_BIT_MASK(64);
+		dev_set_cma_area(&fallback_zone.pdev, def);
+		strlcpy(fallback_zone.name, name, NAME_LEN_MAX);
+		fallback_zone.gfp = 0;
+		fallback_zone.phys_start = cma_get_base(def);
+		fallback_zone.nbytes = cma_get_size(def);
+		return &fallback_zone;
 	}
 
 	return &hisi_zone[i];


### PR DESCRIPTION
## Summary

openhisilicon's V3.5 \`cma_allocator\` (in user-side \`open_osal.ko\`) calls
\`hisi_get_cma_zone(\"anonymous\")\` to look up a CMA region registered via
the kernel cmdline \`mmz=\` early_param. On stock OpenIPC firmware where
the U-Boot bootargs were never customised, no \`mmz=\` is present,
\`hisi_get_cma_zone\` returns NULL, the OSAL allocator fails to register
any zone, and after OpenIPC/openhisilicon#73 propagated \`-ENODEV\` from
the empty-zone case, \`insmod hi_osal.ko\` started failing loud.

Existing hi3516av300 / hi3516cv500 / hi3516dv300 cameras that **worked
for years** stopped loading any vendor module after a sysupgrade.

## Fix

When the named lookup misses, synthesize a single fallback zone that
points to the kernel's default CMA pool (set by \`CONFIG_CMA_SIZE_MBYTES\`
or \`cma=\` in cmdline). The fallback is one-shot (cached in a \`static\`
struct) so subsequent get-by-name calls reuse it.

Boards that DO put \`mmz=anonymous,...\` in bootargs keep their per-zone
intent — named lookup is still tried first.

## Test plan (verified on hi3516av300_imx415)

With **default OpenIPC bootargs (no mmz=, no cma=)** and
\`CONFIG_CMA_SIZE_MBYTES=256\`:

- [x] Boot to login on UART
- [x] All 37 OSDRV modules load (open_osal → ... → open_acodec)
- [x] \`ipcinfo --short-sensor\` returns \`imx415\`
- [x] \`HiSilicon SDK started\`, \`Free MMZ mem after allocation: 257924KB\`
- [x] H.264 4K + MJPEG 4K channels both succeed
- [x] RTSP server on :554, HTTP/HTTPS on :80/:443
- [x] \`curl http://root:12345@CAM/image.jpg\` returns valid 3840×2160
  baseline JPEG (368 KB)

Companion firmware-side change: openipc/firmware bumps
\`CONFIG_CMA_SIZE_MBYTES\` to 256 and disables \`CONFIG_HIGHMEM\` in the
cv500-family generic configs (av300/cv500/dv300). HIGHMEM=y created the
lowmem/highmem boundary at \`0xb0000000\` that broke any CMA region
spanning it; HIGHMEM=n matches what hi3516ev300 has shipped for years.

🤖 Generated with [Claude Code](https://claude.com/claude-code)