### PR TITLE
arm: dts: hisilicon: hi3516dv300: register PL022 SSP controllers

### DIFF
--- a/arch/arm/boot/dts/hisilicon/hi3516dv300.dtsi
+++ b/arch/arm/boot/dts/hisilicon/hi3516dv300.dtsi
@@ -109,6 +109,51 @@
 				clock-names = "apb_pclk";
 				status = "okay";
 			};
+
+			/* PL022 SSP — vendor open_sensor_spi.ko probes
+			 * spi_busnum_to_master() across these and refuses
+			 * to load when no master is registered. Children
+			 * (sensor SPI etc.) are bound at runtime by the
+			 * OSAL stack; we only need the master nodes here. */
+			spi_bus0: spi@120c0000 {
+				compatible = "arm,pl022", "arm,primecell";
+				/* HiSilicon's hardware reports periphid 0x00800022,
+				 * which the mainline pl022 driver doesn't recognise.
+				 * Override to the standard ARM ID — register layout
+				 * is compatible. */
+				arm,primecell-periphid = <0x00041022>;
+				reg = <0x120c0000 0x1000>;
+				interrupts = <0 68 4>;
+				clocks = <&clock HI3516DV300_SPI0_CLK>;
+				clock-names = "apb_pclk";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "okay";
+			};
+
+			spi_bus1: spi@120c1000 {
+				compatible = "arm,pl022", "arm,primecell";
+				arm,primecell-periphid = <0x00041022>;
+				reg = <0x120c1000 0x1000>;
+				interrupts = <0 69 4>;
+				clocks = <&clock HI3516DV300_SPI1_CLK>;
+				clock-names = "apb_pclk";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "okay";
+			};
+
+			spi_bus2: spi@120c2000 {
+				compatible = "arm,pl022", "arm,primecell";
+				arm,primecell-periphid = <0x00041022>;
+				reg = <0x120c2000 0x1000>;
+				interrupts = <0 70 4>;
+				clocks = <&clock HI3516DV300_SPI2_CLK>;
+				clock-names = "apb_pclk";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "okay";
+			};
 		};
 
 		/* SPI NOR flash — boot device */


### PR DESCRIPTION
## Summary

Add \`spi_bus0/1/2\` nodes for the three PL022-compatible SSP controllers at \`0x120c0000\`/\`0x120c1000\`/\`0x120c2000\`. \`CONFIG_SPI_PL022\` is already enabled in the cv500_neo / av300_neo kernel configs, but without DT nodes nothing instantiates the driver, \`/sys/class/spi_master/\` stays empty, and the vendor \`open_sensor_spi.ko\` refuses to load:

\`\`\`
modprobe: can't load module open_sensor_spi: No such device or address
(NULL device *): spi_busnum_to_master() error!
\`\`\`

Children (sensor SPI, codec SPI, etc.) are bound at runtime by the OSAL stack — only the master nodes are needed here.

## Periphid override

HiSilicon's PL022 hardware reports periphid \`0x00800022\`, which the mainline pl022 driver doesn't recognise (it expects \`0x00041022\` for the standard ARM variant). We override via \`arm,primecell-periphid = <0x00041022>\` — the register layout is compatible enough that the driver binds cleanly and the SPI master comes up. Without the override, the AMBA bus reads the hardware ID and no driver matches.

Reads clock IDs from the existing \`dt-bindings/clock/hi3516dv300-clock.h\` (SPI0_CLK=48, SPI1_CLK=49, SPI2_CLK=54) and SPI shared-peripheral IRQs from the vendor 4.9 DTSI (68/69/70).

## Verified on hardware

hi3516av300 + IMX415:

\`\`\`
$ ls /sys/class/spi_master/
spi0  spi1  spi2

$ dmesg | grep ssp-pl022
ssp-pl022 120c0000.spi: ARM PL022 driver, device ID: 0x00041022
ssp-pl022 120c0000.spi: mapped registers from 0x120c0000 to (ptrval)
ssp-pl022 120c1000.spi: ARM PL022 driver, device ID: 0x00041022
ssp-pl022 120c2000.spi: ARM PL022 driver, device ID: 0x00041022

$ dmesg | grep sensor_spi
load sensor_spi.ko for Hi3516CV500...OK !
\`\`\`

Affects: hi3516av300, hi3516cv500, hi3516dv300 boards using this DTSI.

Fixes: OpenIPC/firmware#2069

🤖 Generated with [Claude Code](https://claude.com/claude-code)