### PR TITLE
arm: hisilicon: add hi3519v101 SoC support (DT + ARCH_HI3519V101)

### DIFF
--- a/arch/arm/boot/dts/hisilicon/Makefile
+++ b/arch/arm/boot/dts/hisilicon/Makefile
@@ -26,3 +26,5 @@ dtb-$(CONFIG_ARCH_HI3516CV100) += \
 	hi3516cv100-demb.dtb
 dtb-$(CONFIG_ARCH_HI3516AV100) += \
 	hi3516av100-demb.dtb
+dtb-$(CONFIG_ARCH_HI3519V101) += \
+	hi3519v101-demb.dtb

--- a/arch/arm/boot/dts/hisilicon/hi3519v101-demb.dts
+++ b/arch/arm/boot/dts/hisilicon/hi3519v101-demb.dts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * DTS for Hi3519V101 DEMB (development reference) board.
+ *
+ * Memory: 256 MiB DDR at 0x80000000. The OS is given the lower 32 MiB
+ * (0x80000000-0x82000000); the upper 224 MiB are claimed at runtime by
+ * the openhisilicon mmz.ko allocator — matches the production cv101
+ * load_hisilicon defaults (totalmem=256, osmem=32). The DT memory
+ * node advertises the OS-visible slice only.
+ */
+
+/dts-v1/;
+#include "hi3519v101.dtsi"
+
+/ {
+	model = "HiSilicon Hi3519V101 DEMB Board";
+	compatible = "hisilicon,hi3519v101-demb", "hisilicon,hi3519v101";
+
+	aliases {
+		serial0 = &uart0;
+	};
+
+	memory@80000000 {
+		device_type = "memory";
+		reg = <0x80000000 0x02000000>;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&dual_timer0 {
+	status = "okay";
+};

--- a/arch/arm/boot/dts/hisilicon/hi3519v101.dtsi
+++ b/arch/arm/boot/dts/hisilicon/hi3519v101.dtsi
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * HiSilicon Hi3519V101 SoC DT (V3A generation, Cortex-A17 + Cortex-A7
+ * big.LITTLE; QEMU emulates as a single Cortex-A7).
+ *
+ * Hi3519V101 is a refresh of the original Hi3519 with the same MMIO map.
+ * Per the joint Hi3519V101/Hi3516AV200 hardware guide, every peripheral
+ * address, IRQ, GPIO count, and clock matches the base Hi3519 covered by
+ * the mainline arch/arm/boot/dts/hisilicon/hi3519.dtsi. Re-use that scaffold
+ * via #include and just publish the cv101-specific compatible string.
+ *
+ * Sibling SoC sharing this dtsi: Hi3516AV200 (same die, distinguished only
+ * by the SCSYSID0 sub-variant byte — 5 for AV200, default for V101).
+ */
+
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include "hi3519.dtsi"
+
+/ {
+	compatible = "hisilicon,hi3519v101";
+
+	soc {
+		/* HiGMAC at 0x10050000 — the mainline driver
+		 * (drivers/net/ethernet/hisilicon/hisi_higmac.c) matches
+		 * "hisilicon,hi3519v101-gmac". MDIO bus is a child node;
+		 * the higmac driver looks it up via
+		 * of_get_child_by_name(of_node, "mdio") and reuses the
+		 * parent ethernet device's MMIO window (MDIO regs sit at
+		 * the +0x3c0 sub-region per qemu-hisilicon's hisi-gmac.c
+		 * emulation and the vendor datasheet). qemu-hisilicon
+		 * #105 wired the real hisi-gmac device at this base; on
+		 * real hardware the same address is used. */
+		ethernet@10050000 {
+			compatible = "hisilicon,hi3519v101-gmac";
+			reg = <0x10050000 0x1000>;
+			interrupts = <GIC_SPI 25 IRQ_TYPE_LEVEL_HIGH>;
+			phy-mode = "rmii";
+			phy-handle = <&phy0>;
+
+			mdio {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				phy0: ethernet-phy@1 {
+					reg = <1>;
+				};
+			};
+		};
+	};
+};

--- a/arch/arm/mach-hibvt/Kconfig
+++ b/arch/arm/mach-hibvt/Kconfig
@@ -77,6 +77,23 @@ config ARCH_HI3516AV100
 		SoC family (Cortex-A7 single Linux CPU, ARMv7). Sibling of
 		the older V2 cv200 line (which is ARM926EJ-S / ARMv5TE).
 
+config ARCH_HI3519V101
+	bool "Hisilicon Hi3519V101 / Hi3516AV200 Cortex-A17+A7 family (V3A)"
+	depends on ARCH_MULTI_V7
+	select HAVE_ARM_ARCH_TIMER
+	select ARM_GIC
+	select PINCTRL
+	select COMMON_CLK_HI3519
+	select ARCH_HAS_RESET_CONTROLLER
+	select RESET_CONTROLLER
+	help
+		Support for HiSilicon Hi3519V101 / Hi3516AV200 V3A camera SoC
+		family (Cortex-A17 + Cortex-A7 big.LITTLE die; mainline ARM
+		boots a single Cortex-A7). Reuses the upstream Hi3519 CRG
+		driver — Hi3519V101 inherits the Hi3519 MMIO map verbatim
+		(per HiSilicon's joint Hi3519V101/Hi3516AV200 hardware guide),
+		differing only in the SCSYSID0 sub-variant byte.
+
 config ARCH_HI3516CV500
 	bool "Hisilicon Hi3516CV500 Cortex-A7 family"
 	depends on ARCH_MULTI_V7
@@ -254,6 +271,7 @@ config HI_ZRELADDR
        default "0x80008000" if ARCH_HI3516A
        default "0x80008000" if ARCH_HI3518EV20X
        default "0x80008000" if ARCH_HI3516CV100
+       default "0x80008000" if ARCH_HI3519V101
        default "0x80008000" if ARCH_HI3536DV100
        default "0x80008000" if ARCH_HI3521A
        default "0x40008000" if ARCH_HI3531A


### PR DESCRIPTION
## Summary

Adds device-tree, DEMB board file, and \`ARCH_HI3519V101\` Kconfig for the Hi3519V101 SoC family — V3A generation (Cortex-A17+A7 big.LITTLE on silicon; QEMU and mainline ARM boot as single Cortex-A7). This is the last HiSilicon family that lacked modern Linux support in \`openipc/linux\`.

Hi3519V101 is a refresh of the original Hi3519 covered by the existing mainline \`arch/arm/boot/dts/hisilicon/hi3519.dtsi\` + \`drivers/clk/hisilicon/clk-hi3519.c\`. Per HiSilicon's joint Hi3519V101/Hi3516AV200 hardware guide, every peripheral address, IRQ, GPIO count, and clock matches the base Hi3519:

- GIC at \`0x10301000\`/\`0x10302000\`
- CRG at \`0x12010000\` (driven by \`hisilicon,hi3519-crg\` via the existing CRG driver)
- UART0-4 at \`0x12100000\`-\`0x12104000\`
- SP804 timers at \`0x12000000\`/\`0x12001000\`
- 4× PL022 SPI, 4× I2C, 3× HiMCI
- hi-gmac at \`0x10050000\`

\`hi3519v101.dtsi\` simply \`#include \"hi3519.dtsi\"\` and adds the cv101-specific compatible. \`hi3519v101-demb.dts\` mirrors \`hi3519-demb.dts\` with the OS-visible 32 MiB memory split (load_hisilicon defaults totalmem=256 osmem=32; vendor mmz.ko claims the upper 224 MiB at \`0x82000000\`).

\`ARCH_HI3519V101\` selects \`HAVE_ARM_ARCH_TIMER\` + \`ARM_GIC\` + \`PINCTRL\` + \`COMMON_CLK_HI3519\` + \`ARCH_HAS_RESET_CONTROLLER\`. \`HI_ZRELADDR\` is \`0x80008000\` (V3A family default). No mach .c file needed — kernel boots DT-only (same pattern as the existing \`ARCH_HI3516AV100\`).

Sibling SoC sharing this dtsi: **Hi3516AV200** (same die, distinguished only by the SCSYSID0 sub-variant byte — variant 5 for AV200).

## Test plan

- [x] DTB compiles clean (\`arch/arm/boot/dts/hisilicon/hi3519v101-demb.dtb\` 3599 bytes via dtc against the openipc/linux upstream-patches tree)
- [ ] qemu-system-arm -M hi3519v101 boot test — pending the sibling firmware PR (\`hi3519v101_neo_defconfig\`) and openhisilicon module set adjustment

Companion PRs (chain mirroring the hi3516cv100 work just merged):
- OpenIPC/openhisilicon: hi3519v101 module set against Linux 7.0 (coming next)
- OpenIPC/firmware: \`hi3519v101_neo_defconfig\` + neo kernel config + post-image script (coming after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)