### PR TITLE
net: hisilicon: hisi_femac: advertise software timestamping capability

### DIFF
--- a/drivers/net/ethernet/hisilicon/hisi_femac.c
+++ b/drivers/net/ethernet/hisilicon/hisi_femac.c
@@ -677,6 +677,7 @@ static void hisi_femac_net_set_rx_mode(struct net_device *dev)
 
 static const struct ethtool_ops hisi_femac_ethtools_ops = {
 	.get_link		= ethtool_op_get_link,
+	.get_ts_info		= ethtool_op_get_ts_info,
 	.get_link_ksettings	= phy_ethtool_get_link_ksettings,
 	.set_link_ksettings	= phy_ethtool_set_link_ksettings,
 };


### PR DESCRIPTION
## Summary

One-line addition to the `hisi_femac` ethernet driver's `ethtool_ops` so that `ETHTOOL_GET_TS_INFO` returns `SOF_TIMESTAMPING_TX_SOFTWARE | RX_SOFTWARE | SOFTWARE`. Without this, `linuxptp`'s `ptp4l` exits at startup with:

```
ptp4l[N.NNN]: interface 'eth0' does not support requested timestamping mode
failed to create a clock
```

The MAC has no hardware timestamping unit so we cannot offer anything tighter than software-stamped PTP, but software stamping IS supported by the generic kernel network stack — the driver just needs to *say so* via `.get_ts_info`.

## Why this matters

This unblocks the "precision-time profile" use case for OpenIPC cameras: multi-camera fusion, robotics, photogrammetry, latency measurement, scientific instrumentation. With this patch + `linuxptp` + a local PTP grandmaster on the LAN, frame-event timestamps from the `openipc_frame_ts` chrdev anchor to ~100 µs – 1 ms precision instead of the ~3-5 ms NTP baseline.

Companion work in [OpenIPC/firmware #2138](https://github.com/OpenIPC/firmware/pull/2138) ships the userspace plumbing (linuxptp + opinionated ptp4l.conf + init script). That PR is currently blocked from full bench validation by this driver gap.

## Empirical validation

On `hi3516ev300-neo-node-001` running Linux 7.0 + linuxptp 4.2:

**Before the patch** (stock `hisi_femac.c`):
```
$ ptp4l -i eth0 -S -m -f /etc/ptp4l.conf
ptp4l[N.NNN]: interface 'eth0' does not support requested timestamping mode
failed to create a clock
```

**After the patch:**
```
$ ptp4l -i eth0 -S -m -f /etc/ptp4l.conf
ptp4l[60.655]: port 1 (eth0): INITIALIZING to LISTENING on INIT_COMPLETE
ptp4l[60.656]: port 0 (/var/run/ptp4l): INITIALIZING to LISTENING on INIT_COMPLETE
ptp4l[60.657]: port 0 (/var/run/ptp4lro): INITIALIZING to LISTENING on INIT_COMPLETE
```

Daemon stays alive in LISTENING state and waits for a grandmaster. Same behaviour observed via the `S60precision-time` init script that's shipped in the firmware PR.

## Follow-ups (separate)

The same fix likely applies to other HiSi MAC drivers — `hisi_gemac.c` (Gigabit MAC on cv500/av300) is the most obvious candidate. Each would need its own one-line addition and bench validation on representative hardware.

## Risk

Single-line addition to a const ethtool_ops struct. `ethtool_op_get_ts_info` is a generic kernel helper used by dozens of drivers; it has no side effects beyond advertising the SOFTWARE timestamping bits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)