### PR TITLE
mtd: xmedia_fmc100: add GigaDevice GD5F1GM7UEYIG SPI-NAND ID (0xc8 0x91)

### DIFF
--- a/drivers/mtd/nand/xmedia_fmc100/fmc_spi_nand_ids.c
+++ b/drivers/mtd/nand/xmedia_fmc100/fmc_spi_nand_ids.c
@@ -620,6 +620,35 @@ struct spi_nand_info fmc_spi_nand_flash_table[] = {
 	        .driver    = &spi_driver_general,
 	},
 
+	/* GD 3.3v GD5F1GM7UEYIG 1Gbit (0xc8 0x91), 24bit/1K on-die ECC */
+	{
+	        .name      = "GD5F1GM7UEYIG",
+	        .id        = {0xc8, 0x91},
+	        .id_len    = 2,
+	        .chipsize  = _128M,
+	        .erasesize = _128K,
+	        .pagesize  = _2K,
+	        .oobsize   = 128,
+	        .badblock_pos = BBP_FIRST_PAGE,
+	        .read      = {
+	            &READ_STD(1, INFINITE, 24),
+	            &READ_FAST(1, INFINITE, 133),
+	            &READ_DUAL(1, INFINITE, 133),
+	            &READ_QUAD(1, INFINITE, 133),
+	            0
+	        },
+	        .write     = {
+	            &WRITE_STD(0, 256, 133),
+	            &WRITE_QUAD(0, 256, 133),
+	            0
+	        },
+	        .erase     = {
+	            &ERASE_SECTOR_128K(0, _128K, 133),
+	            0
+	        },
+	        .driver    = &spi_driver_general,
+	},
+
 	/* GD 3.3v GD5F2GQ5UEYIG 2Gbit */
 	{
 	        .name      = "GD5F2GQ5UEYIG",


### PR DESCRIPTION
## Problem

The FMC100 kernel SPI-NAND ID table (`drivers/mtd/nand/xmedia_fmc100/fmc_spi_nand_ids.c`) is missing the **GigaDevice GD5F1GM7UEYIG** — JEDEC `0xc8 0x91`, 1 Gbit / 128 MiB SLC, 2 KB page, 128 KB erase block, 128 B OOB, on-die 24-bit/1K ECC.

On a board using this chip the kernel driver fails to probe:

```
SPI Nand ID Table Version 2.7
nand: This device[c8,91] cannot found in spi nand id table!!
Cannot found a valid SPI Nand Device
bsp_spi_nand_probe(157): Error: driver probe, result: -19
UBI error: cannot open mtd 2, error -19
UBI: block: can't open volume on ubi0_1, err=-19
VFS: Cannot open root device "ubiblock0_1" ... error -6
Kernel panic - not syncing: VFS: Unable to mount root fs on unknown-block(0,0)
```

`u-boot-xmedia` already carries this ID (ID table v2.8) and detects the chip fine, so U-Boot boots but the kernel then can't mount root.

## Fix

Add the `{0xc8, 0x91}` entry. Geometry and op-set are copied verbatim from the identical-geometry `GD5F1GQ5UEYIG` (`0xc8 0x51`) entry (same 1 Gbit / 2 KB page / 128 KB block / 128 B OOB, `spi_driver_general`).

## Test

Verified end-to-end by booting an OpenIPC `gk7205v500` NAND/UBI image (the new `gk7205v500_ultimate` board, OpenIPC/firmware#2200) in `qemu-hisilicon`, whose SPI-NAND model emulates this exact GD5F1GM7 part. **Before:** panic as above. **After:**

```
nand: device found, Manufacturer ID: 0xc8, Chip ID: 0x91
nand: GD/ESMT GD5F1GM7UEYIG
nand: 128MiB, SLC, page size: 2048
ECC:24bit/1k  ECC provided by Flash Memory Controller
block ubiblock0_1: created from ubi0:1(rootfs)
VFS: Mounted root (squashfs filesystem) readonly on device 254:0.
...
Welcome to OpenIPC
openipc-gk7205v500 login:
```

Full chain now works: U-Boot → GD5F1GM7 detect → UBI attach + `rootfs_data` autoresize → kernel volume `bootm` → kernel NAND probe → ubiblock → squashfs root → userspace → login.