### PR TITLE
SAR ADC Driver Fixes

### DIFF
--- a/arch/arm/mach-GM/sar-adc-drv/gm8136.c
+++ b/arch/arm/mach-GM/sar-adc-drv/gm8136.c
@@ -180,7 +180,7 @@ static void _platform_process_xgain0_value(struct dev_data* p_dev_data)
     int          len;
     sar_adc_pub_data new_data;
     
-    adc_val=SAR_ADC_RAW_REG_RD(vbase,FTSAR_ADC_DAT0);
+    adc_val=SAR_ADC_RAW_REG_RD(vbase,FTSAR_ADC_DAT0) & 0x3FF;
     if(g_saradc_debug)
         printk("xgain0_value = %d\n",adc_val);
     
@@ -217,7 +217,7 @@ static void _platform_process_xgain1_value(struct dev_data* p_dev_data)
     int          len;
     sar_adc_pub_data new_data;
     
-    adc_val=SAR_ADC_RAW_REG_RD(vbase,FTSAR_ADC_DAT1);
+    adc_val=SAR_ADC_RAW_REG_RD(vbase,FTSAR_ADC_DAT1) & 0x3FF;
     if(g_saradc_debug)
         printk("xgain1_value = %d\n",adc_val);
     
@@ -569,7 +569,7 @@ void Platform_Process_Volt_Threshold(struct dev_data *p_dev_data)
     static int  out_detect_count = 0  ,int_detect_count = 0;
 	static int  zero_val = 0;
         
-    adc_val=SAR_ADC_RAW_REG_RD(vbase,FTSAR_ADC_DAT2);
+    adc_val=SAR_ADC_RAW_REG_RD(vbase,FTSAR_ADC_DAT2) & 0x3FF;
 
     if(g_saradc_debug)
         printk("Platform_Process_Volt_Threshold=%d-%d-%d\n",adc_val,g_saradc_cvbs_info,g_saradc_forcecvbs);
@@ -661,7 +661,7 @@ int Platform_SAR_ADC_GetData(struct dev_data *p_dev_data , sar_adc_pub_data* new
     unsigned int base = (unsigned int)p_dev_data->io_vadr;
     unsigned int value;
 
-    value=SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT0);
+    value=SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT0) & 0x3FF;
 
     if(g_saradc_debug)
         printk("xgain0_value = %d\n",value);
@@ -673,14 +673,14 @@ int Platform_SAR_ADC_GetData(struct dev_data *p_dev_data , sar_adc_pub_data* new
     }
 #if 0 
 
-    value = SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT1);
+    value = SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT1) & 0x3FF;
     if(value > 0x0) {
         new_data->adc_val = value;
         new_data->status = KEY_XAIN_1;
         return 0;
     }
    
-    value=SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT2); 
+    value=SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT2) & 0x3FF; 
     if(value > 0x0) {
         new_data->adc_val = value;
         new_data->status = KEY_XAIN_2;
@@ -836,15 +836,18 @@ unsigned int Platform_Direct_Get_XGain_Value(unsigned int base , int num)
     unsigned int value = 0;
     
     if(num == 0){
-        value=SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT0);       
+        value=SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT0) & 0x3FF;
+        if(g_saradc_debug){
+            printk(KERN_INFO "SARADC_DirectRead: num=%d raw=%u\n", num, value);
+        }
     }
 
     if(num == 1){
-        value=SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT1);
+        value=SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT1) & 0x3FF;
     }
 
     if(num == 2){
-        value=SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT2);
+        value=SAR_ADC_RAW_REG_RD(base,FTSAR_ADC_DAT2) & 0x3FF;
        
     }
     return value;

--- a/arch/arm/mach-GM/sar-adc-drv/sar_adc_drv.c
+++ b/arch/arm/mach-GM/sar-adc-drv/sar_adc_drv.c
@@ -1073,6 +1073,10 @@ static long file_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
     long ret = 0;
     #endif
 
+    if(Platform_Get_SARADC_Debug()){
+        printk("SARADC: ioctl cmd=0x%x\n", cmd);
+    }
+
 	struct flp_data* p_flp_data = filp->private_data;	
 	struct dev_data* p_dev_data = p_flp_data->p_dev_data;
 	struct dev_specific_data_t* p_data = &p_dev_data->dev_specific_data;
@@ -1153,7 +1157,15 @@ static ssize_t file_read(struct file *filp, char __user *buf, size_t count, loff
 	spin_lock_irqsave(&p_data->lock, cpu_flags);
     if (kfifo_len(&p_data->fifo)==0)
     {
-    	ret = 0;
+        if(Platform_Get_SARADC_Debug()) {
+            printk("SARADC_read: kfifo EMPTY\n");
+        }
+        data.adc_val = Platform_Direct_Get_XGain_Value((unsigned int)p_dev_data->io_vadr, g_xgain_num);
+        data.status = (data.adc_val > 0) ? KEY_XAIN_0 : 0;
+        if (copy_to_user(buf, &data, sizeof(sar_adc_pub_data)))
+            ret = -EFAULT;
+        else
+            ret = sizeof(u8);
         goto exit;
     }
     
@@ -1167,6 +1179,10 @@ static ssize_t file_read(struct file *filp, char __user *buf, size_t count, loff
     	ret = -ERESTARTSYS;
         goto exit;
 	}
+
+    if(Platform_Get_SARADC_Debug()) {
+        printk("SARADC_read: adc_val=%u status=%d count=%zu\n", data.adc_val, data.status, count);
+    }
 
     if (copy_to_user(buf, &data, sizeof(sar_adc_pub_data)))
     {


### PR DESCRIPTION
Two issues fixed in the GM8136 SAR ADC driver:

**1. Missing & 0x3FF bitmask on raw register reads**
The SAR ADC is a 10-bit converter but the DAT registers can contain garbage in the upper bits. Without masking, file_ioctl via Platform_Direct_Get_XGain_Value and _platform_process_xgain0_value / _platform_process_xgain1_value returned values up to ~2 billion instead of the valid 0-1023 range.

Added & 0x3FF to all active DAT register reads in gm8136.c:

_platform_process_xgain0_value (DAT0)
_platform_process_xgain1_value (DAT1)
Platform_SAR_ADC_GetData (DAT0)
Platform_Direct_Get_XGain_Value (DAT0, DAT1, DAT2)

**2. Empty kfifo causing garbage reads in file_read**
When majestic reads from /dev/sar_adc_drv, file_read pulls from a kfifo populated by the polling thread. If the kfifo is empty (polling thread too slow or not scheduled), file_read returned 0 but majestic still displayed uninitialized/stale buffer contents as the ADC value.

Fixed file_read to fall back to a direct hardware register read via Platform_Direct_Get_XGain_Value when the kfifo is empty, ensuring majestic always gets a valid ADC reading.