### PR TITLE
Add PY25Q128HA SPI NOR support for GK7205V300

### DIFF
--- a/drivers/mtd/spi-nor/spi-nor.c
+++ b/drivers/mtd/spi-nor/spi-nor.c
@@ -2353,6 +2353,7 @@ static void bsp_get_spi_lock_info(struct spi_nor *nor, const struct flash_info *
 	switch (JEDEC_MFR(info)) {
 	case SNOR_MFR_GD:
 	case SNOR_MFR_FM:
+	case SNOR_MFR_PUYA:
 	case SNOR_MFR_ESMT:
 	case SNOR_MFR_EON:
 	case SNOR_MFR_SPANSION:

--- a/drivers/mtd/spi-nor/spi-nor.c
+++ b/drivers/mtd/spi-nor/spi-nor.c
@@ -1223,7 +1223,7 @@ static const struct spi_nor_basic_flash_parameter puya_params = {
  * For historical (and compatibility) reasons (before we got above config) some
  * old entries may be missing 4K flag.
  */
-#define SPI_NOR_IDS_VER     "1.2"
+#define SPI_NOR_IDS_VER     "1.3"
 
 /******* SPI Nor ID Table ************************************************************************
  * Version   Manufacturer    	Chip Name    		Chipsize	Block	Vol  	Operation
@@ -1279,6 +1279,7 @@ static const struct spi_nor_basic_flash_parameter puya_params = {
  *		FM		FM25Q128-SOB-T-G	16M		64K	3V3
  *		HUAHONG		H25S64			8M		64K	3V3
  *		HUAHONG		H25S128			16M		64K	3V3
+ * 1.3		Puya		PY25Q128HA		16M		64K	3V3
  ********************************************************************************************/
 static const struct flash_info spi_nor_ids[] = {
 	/* Atmel -- some are (confusingly) marketed as "DataFlash" */
@@ -1624,6 +1625,8 @@ static const struct flash_info spi_nor_ids[] = {
 
 	/*puya 3.3V */
 	{"p25q128h", INFO(0x856018, 0, 64 * 1024, 256,
+		SPI_NOR_DUAL_READ), PARAMS(puya), CLK_MHZ_2X(80) },
+	{"py25q128ha", INFO(0x852018, 0, 64 * 1024, 256,
 		SPI_NOR_DUAL_READ), PARAMS(puya), CLK_MHZ_2X(80) },
 
 	/* FM 3.3v */


### PR DESCRIPTION
## Summary
- Add PY25Q128HA (JEDEC ID 0x852018) to the SPI NOR ID table for goke-gk7205v200
- Bump SPI Nor ID table version to 1.3

## Background
PY25Q128HA is commonly used on GK7205V300 boards but was not recognized by the kernel because only P25Q128H (0x856018) was present. PY25Q128HA reports JEDEC ID 0x852018 (85 20 18).

## Test plan
- [x] Build kernel for GK7205V300
- [x] Flash updated uImage.gk7205v300
- [x] Verify dmesg shows SPI Nor ID Table Version 1.3
- [x] Verify flash is detected as py25q128ha (16 MB)
- [x] Verify MTD read/write operations work

Made with [Cursor](https://cursor.com)