### PR TITLE
dts: sigmastar: infinity6e: set i2c2 padmux to 4 (PAD 44/45) for lens motor driver

### DIFF
--- a/arch/arm/boot/dts/infinity6e.dtsi
+++ b/arch/arm/boot/dts/infinity6e.dtsi
@@ -453,7 +453,7 @@
              *         4 -> PAD_PM_I2CM_SCL, PAD_PM_I2CM_SDA
              *         5 -> PAD_PM_GPIO0, PAD_PM_GPIO1
             */
-            i2c-padmux = <1>;
+            i2c-padmux = <4>;
             interrupts=<GIC_SPI INT_IRQ_MIIC_2 IRQ_TYPE_LEVEL_HIGH>;
             status = "ok";
         };


### PR DESCRIPTION
## 📝 Description

On SigmaStar SSC338Q / Infinity6e IP cameras equipped with motorized varifocal lenses (e.g. Ruimeng MS32006 on `/dev/i2c-2`), the I2C2 lines are physically routed to **PAD 44 (SCL)** and **PAD 45 (SDA)**.

In `arch/arm/boot/dts/infinity6e.dtsi`, `i2c2` was configured with `i2c-padmux = <1>`, causing all I2C transactions to the lens driver to timeout (`ETIMEDOUT 110`).

### Change:
```diff
--- a/arch/arm/boot/dts/infinity6e.dtsi
+++ b/arch/arm/boot/dts/infinity6e.dtsi
@@ -453,7 +453,7 @@
              *         4 -> PAD_PM_I2CM_SCL, PAD_PM_I2CM_SDA
              *         5 -> PAD_PM_GPIO0, PAD_PM_GPIO1
             */
-            i2c-padmux = <1>;
+            i2c-padmux = <4>;
             interrupts=<GIC_SPI INT_IRQ_MIIC_2 IRQ_TYPE_LEVEL_HIGH>;
             status = "ok";
         };
```

### Verification:
- Tested and verified on SigmaStar SSC338Q hardware running OpenIPC Lite and OpenIPC Ultimate (`2.6.08.28`).
- `i2cdetect -y -r 2` immediately detects the MS32006 motor controller at address `0x10`.