### PR TITLE
fh8856: fix JL1101 PHY detection, PHY reset GPIO and SD1 pinctrl on V100 boards

### DIFF
--- a/arch/arm/mach-fh/board-fh8856.c
+++ b/arch/arm/mach-fh/board-fh8856.c
@@ -410,6 +410,19 @@ static void fh_set_rmii_speed(int speed)
 
 static void fh_phy_reset(void)
 {
+#ifdef CONFIG_GPIO_EMACPHY_RESET_UNWIRED
+	/*
+	 * The board config declares CONFIG_GPIO_EMACPHY_RESET as not routed to
+	 * the PHY. On FH8856 boards such as the Asecam PB1 (IF5653-V2) that
+	 * GPIO is pad 46, which is PWM7 there; pulsing it while the RXDV strap
+	 * floats leaves the JL1101 unresponsive on MDIO. The vendor firmware
+	 * does not reset the PHY either, and U-Boot has already brought it up.
+	 *
+	 * Boards that do wire the line - FH8852 among them - keep the reset
+	 * sequence below.
+	 */
+	return;
+#else
 	/*
 	 * RXDV must be low during phy reset
 	 */
@@ -428,7 +441,7 @@ static void fh_phy_reset(void)
 	gpio_free(CONFIG_GPIO_EMACPHY_RXDV);
 
 	fh_pmu_set_reg(0xe8, 0x00101030);
-
+#endif
 }
 
 static struct fh_gmac_platform_data fh_gmac_data = {

--- a/arch/arm/mach-fh/include/mach/board_config.fh8856.appboard
+++ b/arch/arm/mach-fh/include/mach/board_config.fh8856.appboard
@@ -27,6 +27,13 @@
  * GPIO55 -> SD1 WIFI Interrupt
  */
 
+/*
+ * GPIO11 is pad 46 (PWM7) on this board and is not routed to the PHY reset
+ * pin; see fh_phy_reset() in board-fh8856.c. Boards that do wire it, such as
+ * the FH8852 appboard, must not define this.
+ */
+#define CONFIG_GPIO_EMACPHY_RESET_UNWIRED	1
+
 #define CONFIG_GPIO_EMACPHY_RESET	11
 #define CONFIG_GPIO_EMACPHY_RXDV	41
 
@@ -39,7 +46,7 @@
 #define FH_BOARD_8856
 #define CONFIG_PINCTRL_SELECT					\
 		"I2C0", "I2C1", "MIPI", "RMII", "SD0_NO_WP", \
-		"SD1_NO_WP", "SSI0_4BIT", "UART0", "GPIO0", "GPIO1", \
+		"SSI0_4BIT", "UART0", "GPIO0", "GPIO1", \
 		"GPIO2", "GPIO3", "GPIO11", "GPIO13", "GPIO14", \
 		"GPIO19", "GPIO20", "GPIO24", "GPIO25", "GPIO26", \
 		"GPIO27", "GPIO28", "GPIO53", "GPIO55"

--- a/arch/arm/mach-fh/include/mach/board_config.fh8856.testboard
+++ b/arch/arm/mach-fh/include/mach/board_config.fh8856.testboard
@@ -27,6 +27,13 @@
  * GPIO55 -> SD1 WIFI Interrupt
  */
 
+/*
+ * GPIO11 is pad 46 (PWM7) on this board and is not routed to the PHY reset
+ * pin; see fh_phy_reset() in board-fh8856.c. Boards that do wire it, such as
+ * the FH8852 appboard, must not define this.
+ */
+#define CONFIG_GPIO_EMACPHY_RESET_UNWIRED	1
+
 #define CONFIG_GPIO_EMACPHY_RESET	11
 #define CONFIG_GPIO_EMACPHY_RXDV	41
 
@@ -39,7 +46,7 @@
 #define FH_BOARD_8856
 #define CONFIG_PINCTRL_SELECT					\
 		"I2C0", "I2C1", "MIPI", "RMII", "SD0_NO_WP", \
-		"SD1_NO_WP", "SSI0_4BIT", "UART0", "GPIO0", "GPIO1", \
+		"SSI0_4BIT", "UART0", "GPIO0", "GPIO1", \
 		"GPIO2", "GPIO3", "GPIO11", "GPIO13", "GPIO14", \
 		"GPIO19", "GPIO20", "GPIO24", "GPIO25", "GPIO26", \
 		"GPIO27", "GPIO28", "GPIO53", "GPIO55"

--- a/arch/arm/mach-fh/include/mach/board_config.h
+++ b/arch/arm/mach-fh/include/mach/board_config.h
@@ -27,6 +27,13 @@
  * GPIO55 -> SD1 WIFI Interrupt
  */
 
+/*
+ * GPIO11 is pad 46 (PWM7) on this board and is not routed to the PHY reset
+ * pin; see fh_phy_reset() in board-fh8856.c. Boards that do wire it, such as
+ * the FH8852 appboard, must not define this.
+ */
+#define CONFIG_GPIO_EMACPHY_RESET_UNWIRED	1
+
 #define CONFIG_GPIO_EMACPHY_RESET	11
 #define CONFIG_GPIO_EMACPHY_RXDV	41
 
@@ -39,7 +46,7 @@
 #define FH_BOARD_8856
 #define CONFIG_PINCTRL_SELECT					\
 		"I2C0", "I2C1", "MIPI", "RMII", "SD0_NO_WP", \
-		"SD1_NO_WP", "SSI0_4BIT", "UART0", "GPIO0", "GPIO1", \
+		"SSI0_4BIT", "UART0", "GPIO0", "GPIO1", \
 		"GPIO2", "GPIO3", "GPIO11", "GPIO13", "GPIO14", \
 		"GPIO19", "GPIO20", "GPIO24", "GPIO25", "GPIO26", \
 		"GPIO27", "GPIO28", "GPIO53", "GPIO55"

--- a/drivers/net/fh_gmac/fh_gmac_phyt.c
+++ b/drivers/net/fh_gmac/fh_gmac_phyt.c
@@ -84,6 +84,7 @@ int fh_mdio_set_mii(struct mii_bus *bus)
 		switch (pGmac->phydev->phy_id) {
 		case FH_GMAC_PHY_RTL8201:
 		case FH_GMAC_PHY_JL1101:
+		case FH_GMAC_PHY_JL1101_B:
 			fh_mdio_write(bus, phyid,
 					gmac_phyt_rtl8201_page_select, 7);
 			fh_mdio_write(bus, phyid,
@@ -118,6 +119,7 @@ int fh_mdio_set_mii(struct mii_bus *bus)
 		switch (pGmac->phydev->phy_id) {
 		case FH_GMAC_PHY_RTL8201:
 		case FH_GMAC_PHY_JL1101:
+		case FH_GMAC_PHY_JL1101_B:
 			fh_mdio_write(bus, phyid,
 					gmac_phyt_rtl8201_page_select, 7);
 			fh_mdio_write(bus, phyid,

--- a/drivers/net/fh_gmac/fh_gmac_phyt.h
+++ b/drivers/net/fh_gmac/fh_gmac_phyt.h
@@ -12,6 +12,9 @@
 #define FH_GMAC_PHY_RTL8201	0x001CC816
 #define FH_GMAC_PHY_TI83848	0xFFFFFFFF
 #define FH_GMAC_PHY_JL1101	0x937c4023
+/* JLSemi JL1101, newer stepping (e.g. Asecam PB1 / IF5653-V2 with FH8856).
+   Same RMII setup as 0x937c4023. */
+#define FH_GMAC_PHY_JL1101_B	0x937c4024
 
 enum
 {


### PR DESCRIPTION
Three fixes for the FH8856 (V100) as found on the Vatilon PB1 / Asecam board, on top of `fullhan-fh8852v100`.

**1. `fh_gmac`: recognise the JLSemi JL1101 PHY id `0x937c4024`** — a newer stepping of the JL1101 the driver already knows as `0x937c4023`; same RMII setup. Without it the PHY is not recognised and `eth0` never links.

**2. `fh8856`: do not pulse the (unwired) PHY reset GPIO** — `CONFIG_GPIO_EMACPHY_RESET` maps to pad 46, which is `PWM7` on this board and not connected to the PHY. Toggling it during boot left the JL1101 dead on MDIO (no PHY found, no network). U-Boot has already configured the PHY, and the vendor kernel never resets it either.

**3. `fh8856`: drop `SD1_NO_WP` from the default pinctrl selection** — muxing the SD1 pads at boot hangs the SoC on this board, which has no SD1 slot and uses those pads for other functions (the pad-51 `GPIO16` path is where `fh_pinctrl_init_devices()` stalls). No supported FH8856 target uses SD1.

### Verification

Built through the OpenIPC firmware tree (`fh8856v100_lite`) with the kernel fetched from this branch and **only** the tree-wide gcc-compatibility patches applied — no per-board patches — and booted on the board from RAM against a flashed OpenIPC rootfs: `eth0` links, `udhcpc` runs, the streamer starts, login prompt reached, no oops. The same three changes, previously carried as buildroot patches, are running on three converted cameras.

### Known, deliberately not in this PR

Netlink link dumps (`RTM_GETLINK`) oops this kernel in `rtnl_fill_ifinfo()` — `dev` in `rtnl_dump_ifinfo`'s `hlist_for_each_entry_rcu` over `dev_index_head` is a garbage pointer. Reproduced with no vendor modules loaded (only `lo` and `eth0`), so it is in the base kernel + `fh_gmac`, not the SDK blobs — but it is not yet pinned to a line. The firmware side ships a `/sbin/ip` wrapper that avoids netlink for the common operations. Separate issue/PR once it is understood.

### Before / after (Vatilon PB1, FH8856, GC4653; serial console)

Before — stock `fullhan-fh8852v100` kernel on this board: `fh_gmac` finds no PHY (id `0x937c4024` unknown), `eth0` never links; with `SD1_NO_WP` in the default pinctrl selection the SoC stalls in `fh_pinctrl_init_devices()` on pad 51 and the console is lost.

After — kernel built from this branch with only the tree-wide gcc-compat patches, booted from RAM against the OpenIPC rootfs:

```
PHY OUI: 0x937c4024 at phyid: 0
Linux version 3.0.8 (…) #2 Sat Sep 5 11:38:50 EEST 2026
Machine: FH8852
eth0 - (dev. name: fh_gmac - id: 0, IRQ #15
udhcpc: broadcasting discover
fh8856v100 login:
```
`ping` 0 % loss; tcp 22/554/8080 open; divinus reports `chip=FH8856 sensor=gc4653_mipi`. Zero oops. Kernel image 1750724 bytes, unchanged in size from the patched-in-buildroot build it replaces (1750732).

One commit; the three changes are described in its message.
